### PR TITLE
Remove custom strikethrough in preparation of po5's markdown security fix

### DIFF
--- a/client/html/help_comments.tpl
+++ b/client/html/help_comments.tpl
@@ -15,10 +15,6 @@
             <td>links to user &ldquo;Pirate&rdquo;</td>
         </tr>
         <tr>
-            <td><code>~~new~~</code></td>
-            <td>adds strike-through</td>
-        </tr>
-        <tr>
             <td><code>[spoiler]Lelouch survives[/spoiler]</td>
             <td>marks text as spoiler and hides it</td>
         </tr>

--- a/client/js/util/markdown.js
+++ b/client/js/util/markdown.js
@@ -40,17 +40,6 @@ class SjisWrapper extends BaseMarkdownWrapper {
     }
 }
 
-// fix \ before ~ being stripped away
-class TildeWrapper extends BaseMarkdownWrapper {
-    preprocess(text) {
-        return text.replace(/\\~/g, "%%%T");
-    }
-
-    postprocess(text) {
-        return text.replace(/%%%T/g, "\\~");
-    }
-}
-
 // prevent ^#... from being treated as headers, due to tag permalinks
 class TagPermalinkFixWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
@@ -103,13 +92,6 @@ class SmallWrapper extends BaseMarkdownWrapper {
     }
 }
 
-class StrikeThroughWrapper extends BaseMarkdownWrapper {
-    postprocess(text) {
-        text = text.replace(/(^|[^\\])(~~|~)([^~]+)\2/g, "$1<del>$3</del>");
-        return text.replace(/\\~/g, "~");
-    }
-}
-
 class FaviconWrapper extends BaseMarkdownWrapper {
     preprocess(text) {
         return text.replace(
@@ -156,13 +138,11 @@ function formatMarkdown(text) {
     };
     let wrappers = [
         new SjisWrapper(),
-        new TildeWrapper(),
         new TagPermalinkFixWrapper(),
         new EntityPermalinkWrapper(),
         new SearchPermalinkWrapper(),
         new SpoilersWrapper(),
         new SmallWrapper(),
-        new StrikeThroughWrapper(),
         new FaviconWrapper(),
     ];
     text = escapeHtml(text);
@@ -186,12 +166,10 @@ function formatInlineMarkdown(text) {
         headerIds: false,
     };
     let wrappers = [
-        new TildeWrapper(),
         new EntityPermalinkWrapper(),
         new SearchPermalinkWrapper(),
         new SpoilersWrapper(),
         new SmallWrapper(),
-        new StrikeThroughWrapper(),
         new FaviconWrapper(),
     ];
     text = escapeHtml(text);


### PR DESCRIPTION
Back when I first coded descriptions, before they were fully implemented (thanks for adding and improving them btw), I was adding descriptions to my posts, which sometimes included the tilde (~) key. I quickly realized that a custom markdown feature was added using the tilde to make strikethroughs. This would be fine, if it wasn't so buggy. Normally you'd expect a feature like that to be cancel-able by adding a backslash (\\) key before the tilde. Well I tried doing that, to find out that while it worked, it didn't actually remove the backslashes for some reason? Today, I looked into it further, and found out that the previous developer had added a piece of code to stop backslashes from being removed. Turns out when you remove that code, it just stops the backslashes from doing anything at all, and it deletes them. So basically, the backslashes either work and stay in the text, or they do literally nothing and get removed from the text regardless.

This mess of a feature has led me to the conclusion that it would be best if it was removed all together, especially when ~there's something else that does the exact same thing.~ it would just be readded in a better way in future versions.

Also check out @po5's comment down below. 