### PR TITLE
feat: OpenAPI specification

### DIFF
--- a/client/html/help_search_pools.tpl
+++ b/client/html/help_search_pools.tpl
@@ -15,32 +15,16 @@
             <td>having given category (accepts wildcards)</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>created at given date</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>edited at given date</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
             <td><code>post-count</code></td>
-            <td>alias of <code>usages</code></td>
+            <td>used in given number of posts</td>
         </tr>
     </tbody>
 </table>
@@ -62,32 +46,16 @@
             <td>category (A to Z)</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>recently created first</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>recently edited first</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
             <td><code>post-count</code></td>
-            <td>number of posts</td>
+            <td>used in most posts first</td>
         </tr>
     </tbody>
 </table>

--- a/client/html/help_search_posts.tpl
+++ b/client/html/help_search_posts.tpl
@@ -23,16 +23,8 @@
             <td>having given score</td>
         </tr>
         <tr>
-            <td><code>uploader</code></td>
+            <td><code>uploader</code>, <code>upload</code>, <code>submit</code></td>
             <td>uploaded by given user (accepts wildcards)</td>
-        </tr>
-        <tr>
-            <td><code>upload</code></td>
-            <td>alias of upload</td>
-        </tr>
-        <tr>
-            <td><code>submit</code></td>
-            <td>alias of upload</td>
         </tr>
         <tr>
             <td><code>comment</code></td>
@@ -80,7 +72,7 @@
         </tr>
         <tr>
             <td><code>type</code></td>
-            <td>given type of posts. <code>&lt;value&gt;</code> can be either <code>image</code>, <code>animation</code>, <code>flash</code>, or <code>video</code>.</td>
+            <td>type of posts (can be either <code>image</code>, <code>animation</code>, <code>flash</code>, or <code>video</code>)</td>
         </tr>
         <tr>
             <td><code>content-checksum</code></td>
@@ -88,119 +80,55 @@
         </tr>
         <tr>
             <td><code>flag</code></td>
-            <td>having given flag. <code>&lt;value&gt;</code> can be either <code>loop</code> or <code>sound</code>.</td>
+            <td>having given flag (can be either <code>loop</code> or <code>sound</code>)</td>
         </tr>
         <tr>
             <td><code>source</code></td>
-            <td>having given source.</td>
+            <td>having given source</td>
         </tr>
         <tr>
             <td><code>file-size</code></td>
             <td>having given file size (in bytes)</td>
         </tr>
         <tr>
-            <td><code>image-width</code></td>
+            <td><code>image-width</code>, <code>width</code></td>
             <td>having given image width (where applicable)</td>
         </tr>
         <tr>
-            <td><code>image-height</code></td>
+            <td><code>image-height</code>, <code>height</code></td>
             <td>having given image height (where applicable)</td>
         </tr>
         <tr>
-            <td><code>image-area</code></td>
+            <td><code>image-area</code>, <code>area</code></td>
             <td>having given number of pixels (image width * image height)</td>
         </tr>
         <tr>
-            <td><code>image-aspect-ratio</code></td>
+            <td><code>image-aspect-ratio</code>, <code>image-ar</code>, <code>ar</code>, <code>aspect-ratio</code></td>
             <td>having given aspect ratio (image width / image height)</td>
         </tr>
         <tr>
-            <td><code>image-ar</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>width</code></td>
-            <td>alias of <code>image-width</code></td>
-        </tr>
-        <tr>
-            <td><code>height</code></td>
-            <td>alias of <code>image-height</code></td>
-        </tr>
-        <tr>
-            <td><code>area</code></td>
-            <td>alias of <code>image-area</code></td>
-        </tr>
-        <tr>
-            <td><code>ar</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>aspect-ratio</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code>, <code>date</code>, <code>time</code></td>
             <td>posted at given date</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>date</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>edited at given date</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>comment-date</code></td>
+            <td><code>comment-date</code>, <code>comment-time</code></td>
             <td>commented at given date</td>
         </tr>
         <tr>
-            <td><code>comment-time</code></td>
-            <td>alias of <code>comment-date</code></td>
-        </tr>
-        <tr>
-            <td><code>fav-date</code></td>
+            <td><code>fav-date</code>, <code>fav-time</code></td>
             <td>last favorited at given date</td>
         </tr>
         <tr>
-            <td><code>fav-time</code></td>
-            <td>alias of <code>fav-date</code></td>
-        </tr>
-        <tr>
-            <td><code>feature-date</code></td>
+            <td><code>feature-date</code>, <code>feature-time</code></td>
             <td>featured at given date</td>
         </tr>
         <tr>
-            <td><code>feature-time</code></td>
-            <td>alias of <code>feature-time</code></td>
-        </tr>
-        <tr>
-            <td><code>safety</code></td>
-            <td>having given safety. <code>&lt;value&gt;</code> can be either <code>safe</code>, <code>sketchy</code>, or <code>unsafe</code>.</td>
-        </tr>
-        <tr>
-            <td><code>rating</code></td>
-            <td>alias of <code>safety</code></td>
+            <td><code>safety</code>, <code>rating</code></td>
+            <td>having given safety (can be either <code>safe</code>, <code>sketchy</code>, or <code>unsafe</code>)</td>
         </tr>
     </tbody>
 </table>
@@ -222,43 +150,23 @@
             <td>highest scored</td>
         </tr>
         <tr>
-            <td><code>uploader</code></td>
+            <td><code>uploader</code>, <code>upload</code>, <code>submit</code></td>
             <td>uploader name alphabetically</td>
-        </tr>
-        <tr>
-            <td><code>upload</code></td>
-            <td>alias of upload</td>
-        </tr>
-        <tr>
-            <td><code>submit</code></td>
-            <td>alias of upload</td>
         </tr>
         <tr>
             <td><code>pool</code></td>
             <td>in most pools</td>
         </tr>
         <tr>
-            <td><code>comment</code></td>
-            <td>alias of <code>comment-count</code></td>
-        </tr>
-        <tr>
-            <td><code>fav</code></td>
-            <td>alias of <code>fav-count</code></td>
-        </tr>
-        <tr>
-            <td><code>tag-count</code></td>
+            <td><code>tag-count</code>, <code>tag</code></td>
             <td>with most tags</td>
         </tr>
         <tr>
-            <td><code>tag</code></td>
-            <td>alias of <code>tag-count</code></td>
-        </tr>
-        <tr>
-            <td><code>comment-count</code></td>
+            <td><code>comment-count</code>, <code>comment</code></td>
             <td>most commented first</td>
         </tr>
         <tr>
-            <td><code>fav-count</code></td>
+            <td><code>fav-count</code>, <code>fav</code></td>
             <td>loved by most</td>
         </tr>
         <tr>
@@ -290,108 +198,44 @@
             <td>largest files first</td>
         </tr>
         <tr>
-            <td><code>image-width</code></td>
+            <td><code>image-width</code>, <code>width</code></td>
             <td>widest images first</td>
         </tr>
         <tr>
-            <td><code>image-height</code></td>
+            <td><code>image-height</code>, <code>height</code></td>
             <td>tallest images first</td>
         </tr>
         <tr>
-            <td><code>image-area</code></td>
+            <td><code>image-area</code>, <code>area</code></td>
             <td>largest images first</td>
         </tr>
         <tr>
-            <td><code>image-aspect-ratio</code></td>
+            <td><code>image-aspect-ratio</code>, <code>image-ar</code>, <code>ar</code>, <code>aspect-ratio</code></td>
             <td>highest aspect ratio first</td>
         </tr>
         <tr>
-            <td><code>image-ar</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>width</code></td>
-            <td>alias of <code>image-width</code></td>
-        </tr>
-        <tr>
-            <td><code>height</code></td>
-            <td>alias of <code>image-height</code></td>
-        </tr>
-        <tr>
-            <td><code>area</code></td>
-            <td>alias of <code>image-area</code></td>
-        </tr>
-        <tr>
-            <td><code>ar</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>aspect-ratio</code></td>
-            <td>alias of <code>image-aspect-ratio</code></td>
-        </tr>
-        <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code>, <code>date</code>, <code>time</code></td>
             <td>newest to oldest (pretty much same as id)</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>date</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>like creation-date, only looks at last edit time</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>comment-date</code></td>
+            <td><code>comment-date</code>, <code>comment-time</code></td>
             <td>recently commented by anyone</td>
         </tr>
         <tr>
-            <td><code>comment-time</code></td>
-            <td>alias of <code>comment-date</code></td>
-        </tr>
-        <tr>
-            <td><code>fav-date</code></td>
+            <td><code>fav-date</code>, <code>fav-time</code></td>
             <td>recently added to favorites by anyone</td>
         </tr>
         <tr>
-            <td><code>fav-time</code></td>
-            <td>alias of <code>fav-date</code></td>
-        </tr>
-        <tr>
-            <td><code>feature-date</code></td>
+            <td><code>feature-date</code>, <code>feature-time</code></td>
             <td>recently featured</td>
         </tr>
         <tr>
-            <td><code>feature-time</code></td>
-            <td>alias of <code>feature-time</code></td>
-        </tr>
-        <tr>
-            <td><code>safety</code></td>
+            <td><code>safety</code>, <code>rating</code></td>
             <td>most unsafe first</td>
-        </tr>
-        <tr>
-            <td><code>rating</code></td>
-            <td>alias of <code>safety</code></td>
         </tr>
     </tbody>
 </table>

--- a/client/html/help_search_tags.tpl
+++ b/client/html/help_search_tags.tpl
@@ -19,40 +19,16 @@
             <td>having given description (accepts wildcards)</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>created at given date</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>edited at given date</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>last-edit-date</code></td>
-        </tr>
-        <tr>
-            <td><code>usages</code></td>
+            <td><code>usages</code>, <code>usage-count</code>, <code>post-count</code></td>
             <td>used in given number of posts</td>
-        </tr>
-        <tr>
-            <td><code>usage-count</code></td>
-            <td>alias of <code>usages</code></td>
-        </tr>
-        <tr>
-            <td><code>post-count</code></td>
-            <td>alias of <code>usages</code></td>
         </tr>
         <tr>
             <td><code>suggestion-count</code></td>
@@ -94,56 +70,24 @@
             <td>description (A to Z)</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>recently created first</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-edit-date</code></td>
+            <td><code>last-edit-date</code>, <code>last-edit-time</code>, <code>edit-date</code>, <code>edit-time</code></td>
             <td>recently edited first</td>
         </tr>
         <tr>
-            <td><code>last-edit-time</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-date</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
-            <td><code>edit-time</code></td>
-            <td>alias of <code>creation-time</code></td>
-        </tr>
-        <tr>
-            <td><code>usages</code></td>
+            <td><code>usages</code>, <code>usage-count</code>, <code>post-count</code></td>
             <td>used in most posts first</td>
         </tr>
         <tr>
-            <td><code>usage-count</code></td>
-            <td>alias of <code>usages</code></td>
-        </tr>
-        <tr>
-            <td><code>post-count</code></td>
-            <td>alias of <code>usages</code></td>
-        </tr>
-        <tr>
-            <td><code>suggestion-count</code></td>
-            <td>with most suggestions first</td>
-        </tr>
-        <tr>
-            <td><code>implication-count</code></td>
+            <td><code>implication-count</code>, <code>implies</code></td>
             <td>with most implications first</td>
         </tr>
         <tr>
-            <td><code>implies</code></td>
-            <td>alias of <code>implication-count</code></td>
-        </tr>
-        <tr>
-            <td><code>suggests</code></td>
-            <td>alias of <code>suggestion-count</code></td>
+            <td><code>suggestion-count</code>, <code>suggests</code></td>
+            <td>with most suggestions first</td>
         </tr>
     </tbody>
 </table>

--- a/client/html/help_search_users.tpl
+++ b/client/html/help_search_users.tpl
@@ -11,28 +11,12 @@
             <td>having given name (accepts wildcards)</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>registered at given date</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-login-date</code>
+            <td><code>last-login-date</code>, <code>last-login-time</code>, <code>login-date</code>, <code>login-time</code></td>
             <td>whose most recent login date matches given date</td>
-        </tr>
-        <tr>
-            <td><code>last-login-time</code>
-            <td>alias of <code>last-login-date</code>
-        </tr>
-        <tr>
-            <td><code>login-date</code>
-            <td>alias of <code>last-login-date</code>
-        </tr>
-        <tr>
-            <td><code>login-time</code></td>
-            <td>alias of <code>last-login-date</code>
         </tr>
     </tbody>
 </table>
@@ -50,28 +34,12 @@
             <td>A to Z</td>
         </tr>
         <tr>
-            <td><code>creation-date</code></td>
+            <td><code>creation-date</code>, <code>creation-time</code></td>
             <td>newest to oldest</td>
         </tr>
         <tr>
-            <td><code>creation-time</code></td>
-            <td>alias of <code>creation-date</code></td>
-        </tr>
-        <tr>
-            <td><code>last-login-date</code></td>
+            <td><code>last-login-date</code>, <code>last-login-time</code>, <code>login-date</code>, <code>login-time</code></td>
             <td>recently active first</td>
-        </tr>
-        <tr>
-            <td><code>last-login-time</code></td>
-            <td>alias of <code>last-login-date</code></td>
-        </tr>
-        <tr>
-            <td><code>login-date</code></td>
-            <td>alias of <code>last-login-date</code></td>
-        </tr>
-        <tr>
-            <td><code>login-time</code></td>
-            <td>alias of <code>last-login-date</code></td>
         </tr>
     </tbody>
 </table>

--- a/client/nginx.conf.docker
+++ b/client/nginx.conf.docker
@@ -26,6 +26,21 @@ http {
     server {
         listen 80 default_server;
 
+        # Add Swagger UI proxying
+        location /swagger-ui {
+            proxy_pass http://backend/swagger-ui;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+        
+        location /apidoc {
+            proxy_pass http://backend/apidoc;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location ~ ^/api$ {
             return 302 /api/;
         }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2375,9 +2375,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3069,6 +3069,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "serial_test",
+ "server-macros",
  "strum",
  "swf",
  "thiserror 2.0.16",
@@ -3086,6 +3087,15 @@ dependencies = [
  "uuid",
  "video-rs",
  "walkdir",
+]
+
+[[package]]
+name = "server-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3264,9 +3274,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -73,6 +73,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -705,6 +708,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diesel"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1739,6 +1754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1881,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2628,6 +2662,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-multipart-rfc7578_2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,9 +3079,24 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
+ "utoipa-swagger-ui-vendored",
  "uuid",
  "video-rs",
  "walkdir",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3637,6 +3720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,6 +3754,70 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.11.4",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "utoipa-swagger-ui-vendored",
+ "zip",
+]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
@@ -4178,6 +4331,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.11.4",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2143,6 +2143,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxibooru_server"
+version = "0.7.2"
+dependencies = [
+ "argon2",
+ "axum",
+ "axum-test",
+ "base64",
+ "blake3",
+ "byteorder",
+ "compact_str",
+ "config",
+ "diesel",
+ "diesel_migrations",
+ "dotenvy",
+ "flate2",
+ "hex",
+ "image",
+ "lettre",
+ "md5",
+ "mimalloc",
+ "num-traits",
+ "percent-encoding",
+ "rayon",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "serde_repr",
+ "serde_with",
+ "serial_test",
+ "server-macros",
+ "strum",
+ "swf",
+ "thiserror 2.0.16",
+ "time",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
+ "utoipa-swagger-ui-vendored",
+ "uuid",
+ "video-rs",
+ "walkdir",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,58 +3087,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "server"
-version = "0.7.2"
-dependencies = [
- "argon2",
- "axum",
- "axum-test",
- "base64",
- "blake3",
- "byteorder",
- "compact_str",
- "config",
- "diesel",
- "diesel_migrations",
- "dotenvy",
- "flate2",
- "hex",
- "image",
- "lettre",
- "md5",
- "mimalloc",
- "num-traits",
- "percent-encoding",
- "rayon",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "serde_regex",
- "serde_repr",
- "serde_with",
- "serial_test",
- "server-macros",
- "strum",
- "swf",
- "thiserror 2.0.16",
- "time",
- "tokio",
- "tower",
- "tower-http",
- "tracing",
- "tracing-subscriber",
- "url",
- "utoipa",
- "utoipa-axum",
- "utoipa-swagger-ui",
- "utoipa-swagger-ui-vendored",
- "uuid",
- "video-rs",
- "walkdir",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "server"
+name = "oxibooru_server"
 version = "0.7.2"
+license = "GPL-3.0"
 edition = "2024"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0.138"
 serde_regex = "1.1.0"
 serde_repr = "0.1.19"
 serde_with = "3.12.0"
+server-macros = { path = "macros" }
 strum = { version = "0.27.0", features = ["derive", "phf"] }
 swf = "0.2.2"
 thiserror = "2.0.11"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -40,6 +40,10 @@ tower-http = { version = "0.6.6", features = ["trace", "timeout", "normalize-pat
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 url = { version = "2.5.4", features = ["serde"] }
+utoipa = { version = "5.4.0", features = ["axum_extras", "time", "url", "uuid"] }
+utoipa-axum = "0.2.0"
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
+utoipa-swagger-ui-vendored = "0.1.2"
 uuid = { version = "1.13.1", features = ["v4", "serde"] }
 video-rs = "0.10.3"
 walkdir = "2.5.0"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,10 @@ RUN apk update && apk add --no-cache pkgconfig clang-dev postgresql-dev dav1d-de
 
 COPY --from=planner /opt/app/recipe.json recipe.json
 
+# Copy local dependencies for cargo chef cook
+COPY macros/Cargo.toml macros/Cargo.toml
+COPY macros/src macros/src
+
 # Build dependencies (this will be cached for future builds)
 ARG TARGET_CPU
 ARG CODEGEN_OPTIONS="-C target-feature=-crt-static -C target-cpu=$TARGET_CPU"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p /opt/app /data \
  && chown -R app:app /opt/app /data
 
 # Copy over application binary
-COPY --from=builder /opt/app/target/release/server server
+COPY --from=builder /opt/app/target/release/oxibooru_server server
 
 # Run it!
 USER app

--- a/server/macros/Cargo.toml
+++ b/server/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "server-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0.111"
+quote = "1.0.42"
+proc-macro2 = "1.0.104"

--- a/server/macros/src/lib.rs
+++ b/server/macros/src/lib.rs
@@ -1,0 +1,31 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+#[proc_macro_attribute]
+pub fn non_nullable_options(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as DeriveInput);
+
+    if let Data::Struct(data_struct) = &mut input.data
+        && let Fields::Named(fields) = &mut data_struct.fields
+    {
+        for field in fields.named.iter_mut() {
+            // Check if field already has a #[schema(nullable...)] attribute
+            let has_nullable = field.attrs.iter().any(|attr| {
+                attr.path().is_ident("schema")
+                    && attr
+                        .meta
+                        .require_list()
+                        .ok()
+                        .map_or(false, |list| list.tokens.to_string().contains("nullable"))
+            });
+
+            // Only add nullable = false if not already specified
+            if !has_nullable {
+                field.attrs.push(syn::parse_quote!(#[schema(nullable = false)]));
+            }
+        }
+    }
+
+    TokenStream::from(quote!(#input))
+}

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -66,7 +66,7 @@ const MAX_COMMENTS_PER_PAGE: i64 = 1000;
     tag = COMMENT_TAG,
     params(PageParams),
     responses(
-        (status = 200, body = PagedResponse<CommentInfo>, description = "Paged list of comments"),
+        (status = 200, description = "Paged list of comments", body = PagedResponse<CommentInfo>),
         (status = 403, description = "Privileges are too low"),
     )
 )]

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -1,6 +1,6 @@
+use crate::api::doc::COMMENT_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::doc::COMMENT_TAG;
 use crate::api::{DeleteBody, PageParams, PagedResponse, RatingBody, ResourceParams, error};
 use crate::app::AppState;
 use crate::auth::Client;
@@ -140,8 +140,8 @@ struct CommentCreateBody {
 
 /// Creates a new comment under given post.
 #[utoipa::path(
-    post, 
-    path = "/comments", 
+    post,
+    path = "/comments",
     tag = COMMENT_TAG,
     params(ResourceParams),
     request_body = CommentCreateBody,
@@ -189,8 +189,8 @@ struct CommentUpdateBody {
 
 /// Updates an existing comment.
 #[utoipa::path(
-    put, 
-    path = "/comment/{id}", 
+    put,
+    path = "/comment/{id}",
     tag = COMMENT_TAG,
     params(
         ("id" = i64, Path, description = "Comment ID"),
@@ -244,8 +244,8 @@ async fn update(
 ///
 /// Valid scores are -1, 0, and 1.
 #[utoipa::path(
-    put, 
-    path = "/comment/{id}/score", 
+    put,
+    path = "/comment/{id}/score",
     tag = COMMENT_TAG,
     params(
         ("id" = i64, Path, description = "Comment ID"),
@@ -294,8 +294,8 @@ async fn rate(
 
 /// Deletes existing comment.
 #[utoipa::path(
-    delete, 
-    path = "/comment/{id}", 
+    delete,
+    path = "/comment/{id}",
     tag = COMMENT_TAG,
     params(
         ("id" = i64, Path, description = "Comment ID"),

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -66,7 +66,7 @@ const MAX_COMMENTS_PER_PAGE: i64 = 1000;
     tag = COMMENT_TAG,
     params(ResourceParams, PageParams),
     responses(
-        (status = 200, description = "Paged list of comments", body = PagedResponse<CommentInfo>),
+        (status = 200, body = PagedResponse<CommentInfo>),
         (status = 403, description = "Privileges are too low"),
     )
 )]
@@ -108,7 +108,8 @@ async fn list(
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The comment does not exist"),
+        (status = 403, description = "Comment is hidden"),
+        (status = 404, description = "Comment does not exist"),
     ),
 )]
 async fn get(
@@ -148,7 +149,7 @@ struct CommentCreateBody {
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The post does not exist"),
+        (status = 404, description = "Post does not exist"),
     ),
 )]
 async fn create(
@@ -200,8 +201,8 @@ struct CommentUpdateBody {
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The comment does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Comment does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn update(

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -107,7 +107,7 @@ async fn list(
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "Comment does not exist"),
+        (status = 404, description = "The comment does not exist"),
     ),
 )]
 async fn get(
@@ -148,7 +148,7 @@ struct CommentCreateBody {
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "Post does not exist"),
+        (status = 404, description = "The post does not exist"),
     ),
 )]
 async fn create(
@@ -200,8 +200,8 @@ struct CommentUpdateBody {
     responses(
         (status = 200, body = CommentInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "Comment does not exist"),
-        (status = 409, description = "Version is outdated"),
+        (status = 404, description = "The comment does not exist"),
+        (status = 409, description = "The version is outdated"),
     ),
 )]
 async fn update(

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -133,10 +133,8 @@ async fn get(
 #[serde(rename_all = "camelCase")]
 struct CommentCreateBody {
     /// ID of the post to comment on.
-    #[schema(examples(1))]
     post_id: i64,
     /// Comment text.
-    #[schema(examples("This is a test comment"))]
     text: String,
 }
 

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -76,7 +76,7 @@ async fn get(
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-struct CreateBody {
+struct CommentCreateBody {
     post_id: i64,
     text: String,
 }
@@ -86,7 +86,7 @@ async fn create(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<CommentCreateBody>,
 ) -> ApiResult<Json<CommentInfo>> {
     api::verify_privilege(client, state.config.privileges().comment_create)?;
 
@@ -110,7 +110,7 @@ async fn create(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct UpdateBody {
+struct CommentUpdateBody {
     version: DateTime,
     text: String,
 }
@@ -121,7 +121,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path(comment_id): Path<i64>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<CommentUpdateBody>,
 ) -> ApiResult<Json<CommentInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/comment.rs
+++ b/server/src/api/comment.rs
@@ -183,7 +183,7 @@ async fn create(
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 struct CommentUpdateBody {
-    /// Resource version. See [versioning](#/Versioning).
+    /// Resource version. See [versioning](#Versioning).
     version: DateTime,
     /// New comment text.
     text: String,

--- a/server/src/api/doc.rs
+++ b/server/src/api/doc.rs
@@ -98,7 +98,7 @@ yt-dlp can be configured with the `'uploads:use_downloader'` permission
 Finally, in some cases the user might want to reuse one file between the
 requests to save the bandwidth (for example, reverse search + consecutive
 upload). In this case one should use [temporary file
-uploads](#File-Uploads), and pass the tokens returned by the API as
+uploads](#Upload), and pass the tokens returned by the API as
 regular fields appended with a `Token` suffix. For example, to use previously
 uploaded data, which was given token `deadbeef`, in an API that accepts a file
 named `content`, the client should pass `{"contentToken":"deadbeef"}` as part

--- a/server/src/api/doc.rs
+++ b/server/src/api/doc.rs
@@ -55,7 +55,7 @@ client "session" (where the definition of a session is up to the client), so
 that the user's last login time is kept up to date.
 "#;
 
-const USER_TOKEN_AUTHENTICATION_DESCRIPTION: &str = r#"
+const USER_TOKEN_AUTHENTICATION_DESCRIPTION: &str = r"
 User token authentication works similarly to [basic HTTP
 auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Because it
 operates similarly to ***basic HTTP auth*** it is still recommended to connect
@@ -71,12 +71,12 @@ The benefit of token authentication is that beyond the initial login to acquire
 the first token, there is no need to transmit the user password in plaintext
 via basic auth. Additionally tokens can be revoked at anytime allowing a
 cleaner interface for isolating clients from user credentials.
-"#;
+";
 
-const BASIC_REQUESTS_DESCRIPTION: &str = r#"
+const BASIC_REQUESTS_DESCRIPTION: &str = r"
 Every request must use `Content-Type: application/json` and `Accept:
 application/json`. An exception to this rule are requests that upload files.
-"#;
+";
 
 const FILE_UPLOADS_DESCRIPTION: &str = r#"
 Requests that upload files must use `multipart/form-data` encoding. Any request
@@ -106,7 +106,7 @@ of the JSON message body. If the file with the particular token doesn't exist
 or it has expired, the server will show an error.
 "#;
 
-const FIELD_SELECTION_DESCRIPTION: &str = r#"
+const FIELD_SELECTION_DESCRIPTION: &str = r"
 For performance considerations, sometimes the client might want to choose the
 fields the server sends to it in order to improve the query speed. This
 customization is available for top-level fields of most resources. To choose 
@@ -119,7 +119,7 @@ should send a `GET` query like this:
 ```
 GET /posts/?fields=id,tags
 ```
-"#;
+";
 
 const VERSIONING_DESCRIPTION: &str = r#"
 To prevent problems with concurrent resource modification, oxibooru
@@ -143,15 +143,15 @@ about missing parameter. If someone has edited the post in the mean time, the se
 will reject the request as well, in which case the client is encouraged to notify the
 user about the situation."#;
 
-const WEBHOOKS_DESCRIPTION: &str = r#"
+const WEBHOOKS_DESCRIPTION: &str = r"
 System administrators can choose to configure webhooks to track events.
 Webhook URIs can be configured in `config.toml` (See `config.toml.dist` for
 example). Upon any event, the API will send a `POST` request to the listed
 URIs with a snapshot resource generated with anonymous user privileges as the
 message body, in JSON format.
-"#;
+";
 
-const SEARCH_DESCRIPTION: &str = r#"
+const SEARCH_DESCRIPTION: &str = r"
 Search queries are built of tokens that are separated by spaces. Each token can
 be of following form:
 
@@ -203,7 +203,7 @@ Searching for posts with `re:zero` will show an error message about unknown
 named token.
 
 Searching for posts with `re\:zero` will show posts tagged with `re:zero`.
-"#;
+";
 
 const ERROR_DESCRIPTION: &str = r#"
 All errors (except for unhandled fatal server errors) send relevant HTTP status

--- a/server/src/api/doc.rs
+++ b/server/src/api/doc.rs
@@ -1,0 +1,288 @@
+use utoipa::OpenApi;
+
+pub const COMMENT_TAG: &str = "comment";
+pub const INFO_TAG: &str = "info";
+pub const PASSWORD_RESET_TAG: &str = "password_reset";
+pub const POOL_TAG: &str = "pool";
+pub const POOL_CATEGORY_TAG: &str = "pool_category";
+pub const POST_TAG: &str = "post";
+pub const SNAPSHOT_TAG: &str = "snapshot";
+pub const TAG_TAG: &str = "tag";
+pub const TAG_CATEGORY_TAG: &str = "tag_category";
+pub const UPLOAD_TAG: &str = "upload";
+pub const USER_TAG: &str = "user";
+pub const USER_TOKEN_TAG: &str = "user_token";
+
+#[derive(OpenApi)]
+#[openapi(
+    tags(
+        (name = COMMENT_TAG, description = "Comment API endpoints"),
+        (name = INFO_TAG, description = "Info API endpoints"),
+        (name = PASSWORD_RESET_TAG, description = "Password reset API endpoints"),
+        (name = POOL_TAG, description = "Pool API endpoints"),
+        (name = POOL_CATEGORY_TAG, description = "Pool category API endpoints"),
+        (name = POST_TAG, description = "Post API endpoints"),
+        (name = SNAPSHOT_TAG, description = "Snapshot API endpoints"),
+        (name = TAG_TAG, description = "Tag API endpoints"),
+        (name = TAG_CATEGORY_TAG, description = "Tag category API endpoints"),
+        (name = UPLOAD_TAG, description = "Upload API endpoints"),
+        (name = USER_TAG, description = "User API endpoints"),
+        (name = USER_TOKEN_TAG, description = "User token API endpoints"),
+        (name = "Errors", description = ERROR_DESCRIPTION),
+        (name = "Field-Selection", description = FIELD_SELECTION_DESCRIPTION),
+        (name = "Versioning", description = VERSIONING_DESCRIPTION)
+    )
+)]
+pub struct ApiDoc;
+
+const ERROR_DESCRIPTION: &str = r#"
+All errors (except for unhandled fatal server errors) send relevant HTTP status
+code together with JSON of following structure:
+
+```json5
+{
+    "name": "Name of the error, e.g. 'PostNotFound'",
+    "title": "Generic title of error message, e.g. 'Resource Not Found'",
+    "description": "Detailed description of what went wrong, e.g. 'User `rr-` not found."
+}
+```
+
+List of possible error names:
+
+- `AddressInUse`
+- `AddressNotAvailable`
+- `AlreadyInTransaction`
+- `ArgumentListTooLong`
+- `BadConnection`
+- `BrokenPipe`
+- `BrokenTransactionManager`
+- `BytesRejection`
+- `CheckViolation`
+- `ClosedConnection`
+- `CommentNotFound`
+- `ConnectionAborted`
+- `ConnectionRefused`
+- `ConnectionReset`
+- `ContentTypeMismatch`
+- `CrossesDevices`
+- `CryptoError`
+- `CyclicDependency`
+- `Deadlock`
+- `DecodeExhausted`
+- `DeleteDefault`
+- `DeserializationError`
+- `DimensionLimitsExceeded`
+- `DimensionMismatch`
+- `DirectoryNotEmpty`
+- `EmailAddressInvalidDomain`
+- `EmailAddressInvalidInput`
+- `EmailAddressInvalidUser`
+- `EmailAddressMissingParts`
+- `EmailAddressUnbalanced`
+- `EmailCannotParseFilename`
+- `EmailMissingAt`
+- `EmailMissingDomain`
+- `EmailMissingForm`
+- `EmailMissingLocalPart`
+- `EmailMissingTo`
+- `EmailNonAsciiChars`
+- `EmailTooManyFrom`
+- `EmptySwf`
+- `EmptyValue`
+- `EmptyVideo`
+- `EnvironmentVariableNotPresent`
+- `EnvironmentVariableNotUnicode`
+- `ExecutableFileBusy`
+- `ExpiredToken`
+- `ExpressionFailsRegex`
+- `FailedAlready`
+- `FailedConnection`
+- `FailedDecoding`
+- `FailedEmailTransport`
+- `FailedEncoding`
+- `FailedToDeserializeQueryString`
+- `FileAlreadyExists`
+- `FileNotFound`
+- `FileTooLarge`
+- `ForeignKeyViolation`
+- `FromStrError`
+- `HeaderDeserialization`
+- `HostUnreachable`
+- `InsufficientMemory`
+- `InsufficientPrivileges`
+- `Interrupted`
+- `InvalidAuthType`
+- `InvalidBoundary`
+- `InvalidByte`
+- `InvalidCharacter`
+- `InvalidConnectionUrl`
+- `InvalidCString`
+- `InvalidData`
+- `InvalidDigit`
+- `InvalidEncoding`
+- `InvalidExtraData`
+- `InvalidFilename`
+- `InvalidFormat`
+- `InvalidFrameFormat`
+- `InvalidHeader`
+- `InvalidInput`
+- `InvalidLastSymbol`
+- `InvalidLength`
+- `InvalidPadding`
+- `InvalidPassword`
+- `InvalidPhcStringField`
+- `InvalidResizeParameters`
+- `InvalidSort`
+- `InvalidUserRank`
+- `InvalidUtf8InPathParam`
+- `InvalidVersion`
+- `IsADirectory`
+- `JsonDataError`
+- `JsonInvalidData`
+- `JsonInvalidSyntax`
+- `JsonIoError`
+- `JsonSyntaxError`
+- `JsonUnexpectedEOF`
+- `MalformedCredentials`
+- `MalformedToken`
+- `MalformedValue`
+- `MissingCodecParameters`
+- `MissingContent`
+- `MissingContentType`
+- `MissingFormData`
+- `MissingJsonContentType`
+- `MissingMetadata`
+- `MissingPathParams`
+- `MissingSmtpInfo`
+- `MultipartError`
+- `NegativeOverflow`
+- `NetworkDown`
+- `NetworkUnreachable`
+- `NoEmail`
+- `NoMoreData`
+- `NoNamesGiven`
+- `NotADirectory`
+- `NotConnected`
+- `NotInTransaction`
+- `NotLoggedIn`
+- `NotNullViolation`
+- `NotSeekable`
+- `OutOfMemory`
+- `OutOfRange`
+- `ParamNameDuplicated`
+- `ParamNameInvalid`
+- `ParamsMaxExceeded`
+- `PathDeserializeError`
+- `PathParseError`
+- `PathParseErrorAtIndex`
+- `PathParseErrorAtKey`
+- `PermissionDenied`
+- `PhcStringTrailingData`
+- `PoolCategoryNameAlreadyExists`
+- `PoolCategoryNotFound`
+- `PoolNameAlreadyExists`
+- `PoolNotFound`
+- `PoolPostAlreadyExists`
+- `PositiveOverflow`
+- `PostAlreadyFeatured`
+- `PostNotFound`
+- `PostRelationAlreadyExists`
+- `QueryBuilderError`
+- `QuotaExceeded`
+- `ReadExhausted`
+- `ReadOnlyFilesystem`
+- `ReadOnlyTransaction`
+- `RequestError`
+- `ResourceBusy`
+- `ResourceHidden`
+- `ResourceModified`
+- `RollbackTransaction`
+- `RowNotFound`
+- `SelfMerge`
+- `SerializationError`
+- `SerializationFailure`
+- `StaleNetworkFileHandle`
+- `StorageFull`
+- `SwfAvm1ParseError`
+- `SwfInvalidData`
+- `SwfIoError`
+- `SwfParseError`
+- `SwfUnsupported`
+- `TagCategoryNameAlreadyExists`
+- `TagCategoryNotFound`
+- `TagNameAlreadyExists`
+- `TagNotFound`
+- `TimedOut`
+- `TooFewArgs`
+- `TooManyArgs`
+- `TooManyLinks`
+- `UnableToSendCommand`
+- `UnauthorizedPasswordReset`
+- `UnexpectedEof`
+- `UnexpectedOutputSize`
+- `UnimplementedFrameFormat`
+- `UninitializedCodec`
+- `UniqueViolation`
+- `Unsupported`
+- `UnsupportedAlgorithm`
+- `UnsupportedCodecHardwareAccelerationDeviceType`
+- `UnsupportedCodecParameterSets`
+- `UnsupportedColor`
+- `UnsupportedExtension`
+- `UnsupportedFeature`
+- `UnsupportedFormat`
+- `UnsupportedImageDimensions`
+- `UnsupportedPathType`
+- `UserEmailAlreadyExists`
+- `UserNameAlreadyExists`
+- `UsernamePasswordMismatch`
+- `UsernameTokenMismatch`
+- `UserNotFound`
+- `UserTokenNotFound`
+- `Utf8ConversionError`
+- `ValueTooLong`
+- `ValueTooShort`
+- `WouldBlock`
+- `WriteRetryLimitReached`
+- `WriteZero`
+- `WrongNumberOfPathParameters`
+- `ZeroNotAllowed`
+"#;
+
+const FIELD_SELECTION_DESCRIPTION: &str = r#"
+For performance considerations, sometimes the client might want to choose the
+fields the server sends to it in order to improve the query speed. This
+customization is available for top-level fields of most of the
+[resources](#resources). To choose the fields, the client should pass
+`?fields=field1,field2,...` suffix to the query. This works regardless of the
+request type (`GET`, `PUT` etc.).
+
+For example, to list posts while getting only their IDs and tags, the client
+should send a `GET` query like this:
+
+```
+GET /posts/?fields=id,tags
+```
+"#;
+
+const VERSIONING_DESCRIPTION: &str = r#"
+To prevent problems with concurrent resource modification, oxibooru
+implements optimistic locks using resource versions. Each modifiable resource
+has its `version` returned to the client with `GET` requests. At the same time,
+each `PUT` and `DELETE` request sent by the client must present the same
+`version` field to the server with value as it was given in `GET`.
+
+For example, given `GET /post/1`, the server responds like this:
+
+```
+{
+    ...,
+    "version": 2024-09-14T19:06:56.979184564Z
+}
+```
+
+This means the client must then send `{"version": 2024-09-14T19:06:56.979184564Z}`
+back too. If the client fails to do so, the server will reject the request notifying
+about missing parameter. If someone has edited the post in the mean time, the server
+will reject the request as well, in which case the client is encouraged to notify the
+user about the situation."#;

--- a/server/src/api/doc.rs
+++ b/server/src/api/doc.rs
@@ -1,17 +1,17 @@
 use utoipa::OpenApi;
 
-pub const COMMENT_TAG: &str = "comment";
-pub const INFO_TAG: &str = "info";
-pub const PASSWORD_RESET_TAG: &str = "password_reset";
-pub const POOL_TAG: &str = "pool";
-pub const POOL_CATEGORY_TAG: &str = "pool_category";
-pub const POST_TAG: &str = "post";
-pub const SNAPSHOT_TAG: &str = "snapshot";
-pub const TAG_TAG: &str = "tag";
-pub const TAG_CATEGORY_TAG: &str = "tag_category";
-pub const UPLOAD_TAG: &str = "upload";
-pub const USER_TAG: &str = "user";
-pub const USER_TOKEN_TAG: &str = "user_token";
+pub const COMMENT_TAG: &str = "Comment";
+pub const INFO_TAG: &str = "Info";
+pub const PASSWORD_RESET_TAG: &str = "Password-Reset";
+pub const POOL_TAG: &str = "Pool";
+pub const POOL_CATEGORY_TAG: &str = "Pool-Category";
+pub const POST_TAG: &str = "Post";
+pub const SNAPSHOT_TAG: &str = "Snapshot";
+pub const TAG_TAG: &str = "Tag";
+pub const TAG_CATEGORY_TAG: &str = "Tag-Category";
+pub const UPLOAD_TAG: &str = "Upload";
+pub const USER_TAG: &str = "User";
+pub const USER_TOKEN_TAG: &str = "User-Token";
 
 #[derive(OpenApi)]
 #[openapi(
@@ -28,12 +28,182 @@ pub const USER_TOKEN_TAG: &str = "user_token";
         (name = UPLOAD_TAG, description = "Upload API endpoints"),
         (name = USER_TAG, description = "User API endpoints"),
         (name = USER_TOKEN_TAG, description = "User token API endpoints"),
-        (name = "Errors", description = ERROR_DESCRIPTION),
+        (name = "Authentication", description = AUTHENTICATION_DESCRIPTION),
+        (name = "User-Token-Authentication", description = USER_TOKEN_AUTHENTICATION_DESCRIPTION),
+        (name = "Basic-Requests", description = BASIC_REQUESTS_DESCRIPTION),
+        (name = "File-Uploads", description = FILE_UPLOADS_DESCRIPTION),
         (name = "Field-Selection", description = FIELD_SELECTION_DESCRIPTION),
-        (name = "Versioning", description = VERSIONING_DESCRIPTION)
+        (name = "Versioning", description = VERSIONING_DESCRIPTION),
+        (name = "Webhooks", description = WEBHOOKS_DESCRIPTION),
+        (name = "Search", description = SEARCH_DESCRIPTION),
+        (name = "Errors", description = ERROR_DESCRIPTION),
     )
 )]
 pub struct ApiDoc;
+
+const AUTHENTICATION_DESCRIPTION: &str = r#"
+Authentication is achieved by means of [basic HTTP
+auth](https://en.wikipedia.org/wiki/Basic_access_authentication) or through the
+use of [user token authentication](#User-Token-Authentication). For this
+reason, it is recommended to connect through HTTPS. There are no sessions, so
+every privileged request must be authenticated. Available privileges depend on
+the user's rank. The way how rank translates to privileges is defined in the
+server's configuration.
+
+It is recommended to add `?bump-login` GET parameter to the first request in a
+client "session" (where the definition of a session is up to the client), so
+that the user's last login time is kept up to date.
+"#;
+
+const USER_TOKEN_AUTHENTICATION_DESCRIPTION: &str = r#"
+User token authentication works similarly to [basic HTTP
+auth](https://en.wikipedia.org/wiki/Basic_access_authentication). Because it
+operates similarly to ***basic HTTP auth*** it is still recommended to connect
+through HTTPS. The authorization header uses the type of `Token` and the
+username and token are encoded as Base64 and sent as the second parameter.
+
+Example header for user1:token-is-more-secure
+```
+Authorization: Token dXNlcjE6dG9rZW4taXMtbW9yZS1zZWN1cmU=
+```
+
+The benefit of token authentication is that beyond the initial login to acquire
+the first token, there is no need to transmit the user password in plaintext
+via basic auth. Additionally tokens can be revoked at anytime allowing a
+cleaner interface for isolating clients from user credentials.
+"#;
+
+const BASIC_REQUESTS_DESCRIPTION: &str = r#"
+Every request must use `Content-Type: application/json` and `Accept:
+application/json`. An exception to this rule are requests that upload files.
+"#;
+
+const FILE_UPLOADS_DESCRIPTION: &str = r#"
+Requests that upload files must use `multipart/form-data` encoding. Any request
+that bundles user files, must send the request data (which is JSON) as an
+additional file with the special name of `metadata` with `Content-Type: application/json`
+(whereas the actual files must have names specific to the API that is being used).
+
+Alternatively, the server can download the files from the Internet on client's
+behalf. In that case, the request doesn't need to be specially encoded in any
+way. The files, however, should be passed as regular fields appended with a
+`Url` suffix. For example, to use `http://example.com/file.jpg` in an API that
+accepts a file named `content`, the client should pass
+`{"contentUrl":"http://example.com/file.jpg"}` as a part of the JSON message
+body. When creating or updating post content using this method, the server can
+also be configured to employ [yt-dlp](https://github.com/yt-dlp/yt-dlp) to
+download content from popular sites such as youtube, gfycat, etc. Access to
+yt-dlp can be configured with the `'uploads:use_downloader'` permission
+
+Finally, in some cases the user might want to reuse one file between the
+requests to save the bandwidth (for example, reverse search + consecutive
+upload). In this case one should use [temporary file
+uploads](#File-Uploads), and pass the tokens returned by the API as
+regular fields appended with a `Token` suffix. For example, to use previously
+uploaded data, which was given token `deadbeef`, in an API that accepts a file
+named `content`, the client should pass `{"contentToken":"deadbeef"}` as part
+of the JSON message body. If the file with the particular token doesn't exist
+or it has expired, the server will show an error.
+"#;
+
+const FIELD_SELECTION_DESCRIPTION: &str = r#"
+For performance considerations, sometimes the client might want to choose the
+fields the server sends to it in order to improve the query speed. This
+customization is available for top-level fields of most resources. To choose 
+the fields, the client should pass `?fields=field1,field2,...` suffix to the 
+query. This works regardless of the request type (`GET`, `PUT` etc.).
+
+For example, to list posts while getting only their IDs and tags, the client
+should send a `GET` query like this:
+
+```
+GET /posts/?fields=id,tags
+```
+"#;
+
+const VERSIONING_DESCRIPTION: &str = r#"
+To prevent problems with concurrent resource modification, oxibooru
+implements optimistic locks using resource versions. Each modifiable resource
+has its `version` returned to the client with `GET` requests. At the same time,
+each `PUT` and `DELETE` request sent by the client must present the same
+`version` field to the server with value as it was given in `GET`.
+
+For example, given `GET /post/1`, the server responds like this:
+
+```
+{
+    ...,
+    "version": 2024-09-14T19:06:56.979184564Z
+}
+```
+
+This means the client must then send `{"version": 2024-09-14T19:06:56.979184564Z}`
+back too. If the client fails to do so, the server will reject the request notifying
+about missing parameter. If someone has edited the post in the mean time, the server
+will reject the request as well, in which case the client is encouraged to notify the
+user about the situation."#;
+
+const WEBHOOKS_DESCRIPTION: &str = r#"
+System administrators can choose to configure webhooks to track events.
+Webhook URIs can be configured in `config.toml` (See `config.toml.dist` for
+example). Upon any event, the API will send a `POST` request to the listed
+URIs with a snapshot resource generated with anonymous user privileges as the
+message body, in JSON format.
+"#;
+
+const SEARCH_DESCRIPTION: &str = r#"
+Search queries are built of tokens that are separated by spaces. Each token can
+be of following form:
+
+| Syntax            | Token type        | Description                                |
+| ----------------- | ----------------- | ------------------------------------------ |
+| `<value>`         | anonymous tokens  | basic filters                              |
+| `<key>:<value>`   | named tokens      | advanced filters                           |
+| `sort:<style>`    | sort style tokens | sort the results                           |
+| `special:<value>` | special tokens    | filters usually tied to the logged in user |
+
+Anonymous and named tokens support ranged and composite values that
+take following form:
+
+| `<value>` | Description                                           |
+| --------- | ----------------------------------------------------- |
+| `a,b,c`   | will show things that satisfy either `a`, `b` or `c`. |
+| `1..`     | will show things that are equal to or greater than 1. |
+| `..4`     | will show things that are equal to at most 4.         |
+| `1..4`    | will show things that are equal to 1, 2, 3 or 4.      |
+
+Date/time values can be of following form:
+
+- `today`
+- `yesterday`
+- `<year>`
+- `<year>-<month>`
+- `<year>-<month>-<day>`
+
+Some fields, such as user names, can take wildcards (`*`).
+
+All tokens can be negated by prepending them with -.
+
+Sort style token values can be appended with ,asc or ,desc to control the sort 
+direction, which can be also controlled by negating the whole token.
+
+You can escape special characters such as `:`, `*`, and `,` by prepending them with a
+backslash: `\\`.
+
+**Example**
+
+Searching for posts with following query:
+
+    sea -fav-count:8.. type:png uploader:Pirate,Davy
+
+will show png files tagged as sea, that were liked by seven people at most,
+uploaded by user Pirate or Davy.
+
+Searching for posts with `re:zero` will show an error message about unknown
+named token.
+
+Searching for posts with `re\:zero` will show posts tagged with `re:zero`.
+"#;
 
 const ERROR_DESCRIPTION: &str = r#"
 All errors (except for unhandled fatal server errors) send relevant HTTP status
@@ -248,41 +418,3 @@ List of possible error names:
 - `WrongNumberOfPathParameters`
 - `ZeroNotAllowed`
 "#;
-
-const FIELD_SELECTION_DESCRIPTION: &str = r#"
-For performance considerations, sometimes the client might want to choose the
-fields the server sends to it in order to improve the query speed. This
-customization is available for top-level fields of most of the
-[resources](#resources). To choose the fields, the client should pass
-`?fields=field1,field2,...` suffix to the query. This works regardless of the
-request type (`GET`, `PUT` etc.).
-
-For example, to list posts while getting only their IDs and tags, the client
-should send a `GET` query like this:
-
-```
-GET /posts/?fields=id,tags
-```
-"#;
-
-const VERSIONING_DESCRIPTION: &str = r#"
-To prevent problems with concurrent resource modification, oxibooru
-implements optimistic locks using resource versions. Each modifiable resource
-has its `version` returned to the client with `GET` requests. At the same time,
-each `PUT` and `DELETE` request sent by the client must present the same
-`version` field to the server with value as it was given in `GET`.
-
-For example, given `GET /post/1`, the server responds like this:
-
-```
-{
-    ...,
-    "version": 2024-09-14T19:06:56.979184564Z
-}
-```
-
-This means the client must then send `{"version": 2024-09-14T19:06:56.979184564Z}`
-back too. If the client fails to do so, the server will reject the request notifying
-about missing parameter. If someone has edited the post in the mean time, the server
-will reject the request as well, in which case the client is encouraged to notify the
-user about the situation."#;

--- a/server/src/api/error.rs
+++ b/server/src/api/error.rs
@@ -105,40 +105,40 @@ impl ApiError {
             Self::Multipart(err) => err.status(),
             Self::MultipartRejection(err) => err.status(),
             Self::PathRejection(err) => err.status(),
+            Self::Request(err) => err.status().unwrap_or(StatusCode::BAD_REQUEST),
             Self::QueryRejection(err) => err.status(),
             Self::ContentTypeMismatch(..)
+            | Self::HeaderDeserialization(_)
+            | Self::MissingContent(_)
+            | Self::MissingContentType
+            | Self::MissingFormData
+            | Self::MissingMetadata => StatusCode::BAD_REQUEST,
+            Self::NotLoggedIn | Self::Password(_) | Self::UnauthorizedPasswordReset => StatusCode::UNAUTHORIZED,
+            Self::Hidden(_) | Self::InsufficientPrivileges => StatusCode::FORBIDDEN,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::AlreadyExists(_) | Self::ResourceModified => StatusCode::CONFLICT,
+            Self::UnsupportedExtension(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            Self::CyclicDependency(_)
             | Self::DeleteDefault(_)
             | Self::EmptySwf
             | Self::EmptyVideo
             | Self::ExpressionFailsRegex(..)
             | Self::FromStr(_)
-            | Self::HeaderDeserialization(_)
+            | Self::Image(_)
             | Self::InvalidEmail(_)
             | Self::InvalidEmailAddress(_)
             | Self::InvalidSort
             | Self::InvalidTime(_)
             | Self::InvalidUserRank
-            | Self::MissingContent(_)
-            | Self::MissingContentType
-            | Self::MissingFormData
-            | Self::MissingMetadata
             | Self::NoEmail
             | Self::NoNamesGiven(_)
             | Self::NotAnInteger(_)
-            | Self::Request(_)
-            | Self::SelfMerge(_) => StatusCode::BAD_REQUEST,
-            Self::NotLoggedIn | Self::Password(_) | Self::UnauthorizedPasswordReset => StatusCode::UNAUTHORIZED,
-            Self::InsufficientPrivileges => StatusCode::FORBIDDEN,
-            Self::Hidden(_) | Self::NotFound(_) => StatusCode::NOT_FOUND,
-            Self::AlreadyExists(_) | Self::CyclicDependency(_) | Self::ResourceModified => StatusCode::CONFLICT,
-            Self::UnsupportedExtension(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            Self::FailedEmailTransport(_)
-            | Self::InvalidHeader(_)
-            | Self::Image(_)
-            | Self::MissingSmtpInfo
-            | Self::StdIo(_)
+            | Self::SelfMerge(_)
             | Self::SwfDecoding(_)
-            | Self::VideoDecoding(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            | Self::VideoDecoding(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::FailedEmailTransport(_) | Self::InvalidHeader(_) | Self::MissingSmtpInfo | Self::StdIo(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
             Self::UnimplementedFrameFormat(_) => StatusCode::NOT_IMPLEMENTED,
             Self::FailedConnection(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::FailedAuthentication(err) => match err {

--- a/server/src/api/error.rs
+++ b/server/src/api/error.rs
@@ -274,7 +274,7 @@ pub fn map_unique_or_foreign_key_violation<T>(
     }
 }
 
-/// Represents a response if an error occured.
+/// Response body for errors.
 #[derive(Serialize)]
 struct ErrorResponse {
     title: &'static str,

--- a/server/src/api/error.rs
+++ b/server/src/api/error.rs
@@ -106,9 +106,7 @@ impl ApiError {
             Self::MultipartRejection(err) => err.status(),
             Self::PathRejection(err) => err.status(),
             Self::QueryRejection(err) => err.status(),
-            Self::AlreadyExists(_)
-            | Self::ContentTypeMismatch(..)
-            | Self::CyclicDependency(_)
+            Self::ContentTypeMismatch(..)
             | Self::DeleteDefault(_)
             | Self::EmptySwf
             | Self::EmptyVideo
@@ -132,7 +130,7 @@ impl ApiError {
             Self::NotLoggedIn | Self::Password(_) | Self::UnauthorizedPasswordReset => StatusCode::UNAUTHORIZED,
             Self::InsufficientPrivileges => StatusCode::FORBIDDEN,
             Self::Hidden(_) | Self::NotFound(_) => StatusCode::NOT_FOUND,
-            Self::ResourceModified => StatusCode::CONFLICT,
+            Self::AlreadyExists(_) | Self::CyclicDependency(_) | Self::ResourceModified => StatusCode::CONFLICT,
             Self::UnsupportedExtension(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             Self::FailedEmailTransport(_)
             | Self::InvalidHeader(_)

--- a/server/src/api/info.rs
+++ b/server/src/api/info.rs
@@ -54,7 +54,7 @@ struct InfoResponse {
     tag = INFO_TAG,
     params(ResourceParams),
     responses(
-        (status = 200, description = "Server information", body = InfoResponse),
+        (status = 200, body = InfoResponse),
     ),
 )]
 async fn get(

--- a/server/src/api/info.rs
+++ b/server/src/api/info.rs
@@ -49,8 +49,8 @@ struct InfoResponse {
 /// consistent with other dates. Values in the `config` key are taken directly
 /// from the server config.
 #[utoipa::path(
-    get, 
-    path = "/info", 
+    get,
+    path = "/info",
     tag = INFO_TAG,
     params(ResourceParams),
     responses(

--- a/server/src/api/info.rs
+++ b/server/src/api/info.rs
@@ -1,6 +1,6 @@
-use crate::api::ResourceParams;
 use crate::api::error::ApiResult;
 use crate::api::extract::{Json, Query};
+use crate::api::{INFO_TAG, ResourceParams};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::PublicConfig;
@@ -11,12 +11,13 @@ use crate::schema::{database_statistics, post_feature, user};
 use crate::string::SmallString;
 use crate::time::DateTime;
 use axum::extract::{Extension, State};
-use axum::routing::{self, Router};
 use diesel::{Connection, ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
 use serde::Serialize;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub fn routes() -> Router<AppState> {
-    Router::new().route("/info", routing::get(get))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(get))
 }
 
 // TODO: Remove renames by changing references to these names in client
@@ -32,7 +33,7 @@ struct Response {
     config: PublicConfig,
 }
 
-/// See [getting-global-info](https://github.com/liamw1/oxibooru/blob/master/docs/API.md#getting-global-info)
+#[utoipa::path(get, path = "/info", tag = INFO_TAG)]
 async fn get(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,

--- a/server/src/api/info.rs
+++ b/server/src/api/info.rs
@@ -1,6 +1,7 @@
+use crate::api::ResourceParams;
+use crate::api::doc::INFO_TAG;
 use crate::api::error::ApiResult;
 use crate::api::extract::{Json, Query};
-use crate::api::{INFO_TAG, ResourceParams};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::PublicConfig;

--- a/server/src/api/info.rs
+++ b/server/src/api/info.rs
@@ -25,7 +25,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 /// Server information response.
 #[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-struct Response {
+struct InfoResponse {
     /// Total number of posts on the server.
     post_count: i64,
     /// Total disk usage in bytes.
@@ -54,14 +54,14 @@ struct Response {
     tag = INFO_TAG,
     params(ResourceParams),
     responses(
-        (status = 200, body = Response, description = "Server information"),
+        (status = 200, description = "Server information", body = InfoResponse),
     ),
 )]
 async fn get(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-) -> ApiResult<Json<Response>> {
+) -> ApiResult<Json<InfoResponse>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
     state.get_connection()?.transaction(|conn| {
         let (post_count, disk_usage) = database_statistics::table
@@ -87,7 +87,7 @@ async fn get(
             .transpose()?
             .flatten();
 
-        Ok(Json(Response {
+        Ok(Json(InfoResponse {
             post_count,
             disk_usage,
             featured_post,

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -104,7 +104,7 @@ impl Deref for RatingBody {
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 struct DeleteBody {
-    /// Resource version. See [versioning](#/Versioning).
+    /// Resource version. See [versioning](#Versioning).
     version: DateTime,
 }
 
@@ -132,7 +132,7 @@ struct ResourceParams {
     #[param(example = "anonymous_token")]
     #[schema(examples("anonymous_token named_token:value1,value2,value3 sort:sort_token"))]
     query: Option<String>,
-    /// Comma-separated list of fields to include in the response. See [field selection](#/Field-Selection) for details.
+    /// Comma-separated list of fields to include in the response. See [field selection](#Field-Selection) for details.
     #[param(example = "field1,field2")]
     #[schema(examples("field1,field2,field3"))]
     fields: Option<String>,
@@ -176,23 +176,25 @@ impl PageParams {
     }
 }
 
-/// Represents a response to a request to retrieve multiple resources.
-/// Used for resources which are not paged.
+/// A result of search operation that doesn't involve paging.
 #[derive(Serialize, ToSchema)]
 struct UnpagedResponse<T> {
     results: Vec<T>,
 }
 
-/// Represents a response to a request to retrieve multiple resources.
-/// Used for resources which are paged.
+/// A result of search operation that involves paging.
 #[derive(Serialize, ToSchema)]
 struct PagedResponse<T> {
+    /// The query passed in the original request that contains a standard [search query](#Search).
     #[schema(examples("anonymous_token named_token:value1,value2,value3 sort:sort_token"))]
     query: Option<String>,
+    /// The record starting offset, passed in the original request.
     #[schema(examples(0))]
     offset: i64,
+    /// Number of records on one page.
     #[schema(examples(40))]
     limit: i64,
+    /// How many resources were found. To get the page count, divide this number by `limit`.
     #[schema(examples(1729))]
     total: i64,
     results: Vec<T>,

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -130,15 +130,13 @@ struct MergeBody<T> {
 }
 
 /// Represents parameters of a request to retrieve one or more resources.
-#[derive(Deserialize, IntoParams, ToSchema)]
+#[derive(Deserialize, IntoParams)]
 struct ResourceParams {
     /// Query search string
     #[param(example = "anonymous_token")]
-    #[schema(examples("anonymous_token named_token:value1,value2,value3 sort:sort_token"))]
     query: Option<String>,
     /// Comma-separated list of fields to include in the response. See [field selection](#Field-Selection) for details.
     #[param(example = "field1,field2")]
-    #[schema(examples("field1,field2,field3"))]
     fields: Option<String>,
 }
 
@@ -161,23 +159,6 @@ struct PageParams {
     /// Maximum number of results to return
     #[param(value_type = i64, minimum = 1, example = 40)]
     limit: NonZeroI64,
-    #[param(inline)]
-    #[serde(flatten)]
-    params: ResourceParams,
-}
-
-impl PageParams {
-    fn criteria(&self) -> &str {
-        self.params.criteria()
-    }
-
-    fn fields(&self) -> Option<&str> {
-        self.params.fields()
-    }
-
-    fn into_query(self) -> Option<String> {
-        self.params.query
-    }
 }
 
 /// A result of search operation that doesn't involve paging.

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -115,13 +115,17 @@ impl Deref for DeleteBody {
     }
 }
 
-/// Represents body of a request to merge two resources.
+/// Request body for merging resources.
 #[derive(Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 struct MergeBody<T> {
+    /// ID of the source resource to be removed.
     remove: T,
+    /// ID of the target resource to merge into.
     merge_to: T,
+    /// Version of the source resource. See [versioning](#Versioning).
     remove_version: DateTime,
+    /// Version of the target resource. See [versioning](#Versioning).
     merge_to_version: DateTime,
 }
 

--- a/server/src/api/password_reset.rs
+++ b/server/src/api/password_reset.rs
@@ -145,8 +145,8 @@ fn generate_temporary_password(length: u8) -> String {
 ///
 /// Password is sent as plain-text, so it is recommended to connect through HTTPS.
 #[utoipa::path(
-    post, 
-    path = "/password-reset/{identifier}", 
+    post,
+    path = "/password-reset/{identifier}",
     tag = PASSWORD_RESET_TAG,
     params(
         ("identifier" = String, Path, description = "User email or username"),

--- a/server/src/api/password_reset.rs
+++ b/server/src/api/password_reset.rs
@@ -1,4 +1,4 @@
-use crate::api::PASSWORD_RESET_TAG;
+use crate::api::doc::PASSWORD_RESET_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path};
 use crate::app::AppState;

--- a/server/src/api/password_reset.rs
+++ b/server/src/api/password_reset.rs
@@ -56,8 +56,8 @@ fn get_user_info(
     ),
     responses(
         (status = 200, description = "Password reset email sent", body = ()),
-        (status = 400, description = "The user hasn't provided an email address"),
-        (status = 404, description = "The user does not exist"),
+        (status = 404, description = "User does not exist"),
+        (status = 422, description = "User hasn't provided an email address"),
     ),
 )]
 async fn request_reset(State(state): State<AppState>, Path(identifier): Path<SmallString>) -> ApiResult<Json<()>> {
@@ -154,9 +154,8 @@ fn generate_temporary_password(length: u8) -> String {
     request_body = ResetToken,
     responses(
         (status = 200, description = "New password generated", body = NewPassword),
-        (status = 400, description = "The token is missing"),
-        (status = 400, description = "The token is invalid"),
-        (status = 404, description = "The user does not exist"),
+        (status = 400, description = "Token is missing or invalid"),
+        (status = 404, description = "User does not exist"),
     ),
 )]
 async fn reset_password(

--- a/server/src/api/password_reset.rs
+++ b/server/src/api/password_reset.rs
@@ -56,8 +56,8 @@ fn get_user_info(
     ),
     responses(
         (status = 200, description = "Password reset email sent", body = ()),
-        (status = 400, description = "User hasn't provided an email address"),
-        (status = 404, description = "User does not exist"),
+        (status = 400, description = "The user hasn't provided an email address"),
+        (status = 404, description = "The user does not exist"),
     ),
 )]
 async fn request_reset(State(state): State<AppState>, Path(identifier): Path<SmallString>) -> ApiResult<Json<()>> {
@@ -154,8 +154,9 @@ fn generate_temporary_password(length: u8) -> String {
     request_body = ResetToken,
     responses(
         (status = 200, description = "New password generated", body = NewPassword),
-        (status = 400, description = "Token is missing or invalid"),
-        (status = 404, description = "User does not exist"),
+        (status = 400, description = "The token is missing"),
+        (status = 400, description = "The token is invalid"),
+        (status = 404, description = "The user does not exist"),
     ),
 )]
 async fn reset_password(

--- a/server/src/api/pool.rs
+++ b/server/src/api/pool.rs
@@ -42,7 +42,7 @@ const MAX_POOLS_PER_PAGE: i64 = 1000;
 ///
 /// **Named tokens**
 ///
-/// | `<key>`                                                      | Description                               |
+/// | Key                                                          | Description                               |
 /// | ------------------------------------------------------------ | ----------------------------------------- |
 /// | `name`                                                       | having given name (accepts wildcards)     |
 /// | `category`                                                   | having given category (accepts wildcards) |
@@ -50,23 +50,23 @@ const MAX_POOLS_PER_PAGE: i64 = 1000;
 /// | `last-edit-date`, `last-edit-time`, `edit-date`, `edit-time` | edited at given date                      |
 /// | `post-count`                                                 | used in given number of posts             |
 ///
-/// **Sort style tokens** 
+/// **Sort style tokens**
 ///
-/// | `<value>`                                                    | Description                  |
-/// | ------------------------------------------------------------ | ---------------------------- |
-/// | `random`                                                     | as random as it can get      |
-/// | `name`                                                       | A to Z                       |
-/// | `category`                                                   | category (A to Z)            |
-/// | `creation-date`, `creation-time`                             | recently created first       |
-/// | `last-edit-date`, `last-edit-time`, `edit-date`, `edit-time` | recently edited first        |
-/// | `post-count`                                                 | used in most posts first     |
+/// | Value                                                        | Description              |
+/// | ------------------------------------------------------------ | ------------------------ |
+/// | `random`                                                     | as random as it can get  |
+/// | `name`                                                       | A to Z                   |
+/// | `category`                                                   | category (A to Z)        |
+/// | `creation-date`, `creation-time`                             | recently created first   |
+/// | `last-edit-date`, `last-edit-time`, `edit-date`, `edit-time` | recently edited first    |
+/// | `post-count`                                                 | used in most posts first |
 ///
 /// **Special tokens**
 ///
 /// None.
 #[utoipa::path(
-    get, 
-    path = "/pools", 
+    get,
+    path = "/pools",
     tag = POOL_TAG,
     params(PageParams),
     responses(
@@ -102,8 +102,8 @@ async fn list(
 
 /// Retrieves information about an existing pool.
 #[utoipa::path(
-    get, 
-    path = "/pool/{id}", 
+    get,
+    path = "/pool/{id}",
     tag = POOL_TAG,
     params(
         ("id" = i64, Path, description = "Pool ID"),
@@ -156,8 +156,8 @@ struct PoolCreateBody {
 /// pool category resource. `posts` is an optional list of integer post IDs.
 /// If the specified posts do not exist, an error will be thrown.
 #[utoipa::path(
-    post, 
-    path = "/pool", 
+    post,
+    path = "/pool",
     tag = POOL_TAG,
     params(ResourceParams),
     request_body = PoolCreateBody,
@@ -223,8 +223,8 @@ async fn create(
 ///
 /// Other pool properties such as category do not get transferred and are discarded.
 #[utoipa::path(
-    post, 
-    path = "/pool-merge", 
+    post,
+    path = "/pool-merge",
     tag = POOL_TAG,
     params(ResourceParams),
     request_body = MergeBody<i64>,
@@ -301,8 +301,8 @@ struct PoolUpdateBody {
 /// and the previous list of posts will be replaced with the new one.
 /// All fields except `version` are optional - update concerns only provided fields.
 #[utoipa::path(
-    put, 
-    path = "/pool/{id}", 
+    put,
+    path = "/pool/{id}",
     tag = POOL_TAG,
     params(
         ("id" = i64, Path, description = "Pool ID"),
@@ -390,8 +390,8 @@ async fn update(
 ///
 /// All posts in the pool will only have their relation to the pool removed.
 #[utoipa::path(
-    delete, 
-    path = "/pool/{id}", 
+    delete,
+    path = "/pool/{id}",
     tag = POOL_TAG,
     params(
         ("id" = i64, Path, description = "Pool ID"),

--- a/server/src/api/pool.rs
+++ b/server/src/api/pool.rs
@@ -164,12 +164,13 @@ struct PoolCreateBody {
     request_body = PoolCreateBody,
     responses(
         (status = 200, body = PoolInfo),
-        (status = 400, description = "Any name is invalid"),
-        (status = 400, description = "No name was specified"),
-        (status = 400, description = "Category is invalid"),
-        (status = 400, description = "There is at least one duplicate post"),
         (status = 403, description = "Privileges are too low"),
         (status = 404, description = "At least one post ID does not exist"),
+        (status = 409, description = "Any name is used by an existing pool"),
+        (status = 409, description = "There is at least one duplicate post"),
+        (status = 422, description = "A name is invalid"),
+        (status = 422, description = "No name was specified"),
+        (status = 422, description = "Category is missing or invalid"),
     ),
 )]
 async fn create(
@@ -231,10 +232,10 @@ async fn create(
     request_body = MergeBody<i64>,
     responses(
         (status = 200, body = PoolInfo),
-        (status = 400, description = "The source pool is the same as the target pool"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The source or target pool does not exist"),
-        (status = 409, description = "The version of either pool is outdated"),
+        (status = 404, description = "Source or target pool does not exist"),
+        (status = 409, description = "Version of either pool is outdated"),
+        (status = 422, description = "Source pool is the same as the target pool"),
     ),
 )]
 async fn merge(
@@ -312,14 +313,15 @@ struct PoolUpdateBody {
     request_body = PoolUpdateBody,
     responses(
         (status = 200, body = PoolInfo),
-        (status = 400, description = "Any name is invalid"),
-        (status = 400, description = "No name was specified"),
-        (status = 400, description = "Category is invalid"),
-        (status = 400, description = "There is at least one duplicate post"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The pool does not exist"),
+        (status = 404, description = "Pool does not exist"),
         (status = 404, description = "At least one post ID does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 409, description = "Version is outdated"),
+        (status = 409, description = "Any name is used by an existing pool"),
+        (status = 409, description = "There is at least one duplicate post"),
+        (status = 422, description = "A name is invalid"),
+        (status = 422, description = "No name was specified"),
+        (status = 422, description = "Category is invalid"),
     ),
 )]
 async fn update(
@@ -401,8 +403,8 @@ async fn update(
     responses(
         (status = 200, body = ()),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The pool does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Pool does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn delete(

--- a/server/src/api/pool.rs
+++ b/server/src/api/pool.rs
@@ -83,7 +83,7 @@ async fn get(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateBody {
+struct PoolCreateBody {
     names: Vec<SmallString>,
     category: SmallString,
     description: Option<LargeString>,
@@ -95,7 +95,7 @@ async fn create(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<PoolCreateBody>,
 ) -> ApiResult<Json<PoolInfo>> {
     api::verify_privilege(client, state.config.privileges().pool_create)?;
 
@@ -181,7 +181,7 @@ async fn merge(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct UpdateBody {
+struct PoolUpdateBody {
     version: DateTime,
     category: Option<SmallString>,
     description: Option<LargeString>,
@@ -195,7 +195,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path(pool_id): Path<i64>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<PoolUpdateBody>,
 ) -> ApiResult<Json<PoolInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/pool.rs
+++ b/server/src/api/pool.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::POOL_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::{DeleteBody, MergeBody, POOL_TAG, PageParams, PagedResponse, ResourceParams};
+use crate::api::{DeleteBody, MergeBody, PageParams, PagedResponse, ResourceParams};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::model::enums::ResourceType;

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -66,7 +66,7 @@ async fn get(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateBody {
+struct PoolCategoryCreateBody {
     name: SmallString,
     color: SmallString,
 }
@@ -76,7 +76,7 @@ async fn create(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<PoolCategoryCreateBody>,
 ) -> ApiResult<Json<PoolCategoryInfo>> {
     api::verify_privilege(client, state.config.privileges().pool_category_create)?;
     api::verify_matches_regex(&state.config, &body.name, RegexType::PoolCategory)?;
@@ -106,7 +106,7 @@ async fn create(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct UpdateBody {
+struct PoolCategoryUpdateBody {
     version: DateTime,
     name: Option<SmallString>,
     color: Option<SmallString>,
@@ -118,7 +118,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path(name): Path<SmallString>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<PoolCategoryUpdateBody>,
 ) -> ApiResult<Json<PoolCategoryInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -113,9 +113,10 @@ struct PoolCategoryCreateBody {
     request_body = PoolCategoryCreateBody,
     responses(
         (status = 200, body = PoolCategoryInfo),
-        (status = 400, description = "Name or color is invalid or missing"),
+        (status = 400, description = "The name is invalid or missing"),
+        (status = 400, description = "The color is invalid or missing"),
         (status = 403, description = "Privileges are too low"),
-        (status = 409, description = "Name is used by an existing pool category"),
+        (status = 409, description = "The Name is used by an existing pool category"),
     ),
 )]
 async fn create(
@@ -178,10 +179,12 @@ struct PoolCategoryUpdateBody {
     request_body = PoolCategoryUpdateBody,
     responses(
         (status = 200, description = "Updated pool category", body = PoolCategoryInfo),
-        (status = 400, description = "Name or color is invalid"),
+        (status = 400, description = "The name is invalid"),
+        (status = 400, description = "The color is invalid"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "Pool category does not exist"),
-        (status = 409, description = "Version is outdated or name is used by an existing pool category"),
+        (status = 404, description = "The Pool category does not exist"),
+        (status = 409, description = "The version is outdated"),
+        (status = 409, description = "The name is used by an existing pool category"),
     ),
 )]
 async fn update(
@@ -315,7 +318,7 @@ async fn set_default(
         (status = 400, description = "Pool category is the default category"),
         (status = 403, description = "Privileges are too low"),
         (status = 404, description = "Pool category does not exist"),
-        (status = 409, description = "Version is outdated"),
+        (status = 409, description = "The version is outdated"),
     ),
 )]
 async fn delete(

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::POOL_CATEGORY_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::{DeleteBody, POOL_CATEGORY_TAG, ResourceParams, UnpagedResponse, error};
+use crate::api::{DeleteBody, ResourceParams, UnpagedResponse, error};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::RegexType;

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -35,7 +35,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
     tag = POOL_CATEGORY_TAG,
     params(ResourceParams),
     responses(
-        (status = 200, description = "List of pool categories", body = UnpagedResponse<PoolCategoryInfo>),
+        (status = 200, body = UnpagedResponse<PoolCategoryInfo>),
         (status = 403, description = "Privileges are too low"),
     ),
 )]
@@ -113,10 +113,10 @@ struct PoolCategoryCreateBody {
     request_body = PoolCategoryCreateBody,
     responses(
         (status = 200, body = PoolCategoryInfo),
-        (status = 400, description = "The name is invalid or missing"),
-        (status = 400, description = "The color is invalid or missing"),
         (status = 403, description = "Privileges are too low"),
-        (status = 409, description = "The Name is used by an existing pool category"),
+        (status = 409, description = "Name is used by an existing pool category"),
+        (status = 422, description = "Name is invalid or missing"),
+        (status = 422, description = "Color is invalid or missing"),
     ),
 )]
 async fn create(
@@ -178,13 +178,13 @@ struct PoolCategoryUpdateBody {
     ),
     request_body = PoolCategoryUpdateBody,
     responses(
-        (status = 200, description = "Updated pool category", body = PoolCategoryInfo),
-        (status = 400, description = "The name is invalid"),
-        (status = 400, description = "The color is invalid"),
+        (status = 200, body = PoolCategoryInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The Pool category does not exist"),
-        (status = 409, description = "The version is outdated"),
-        (status = 409, description = "The name is used by an existing pool category"),
+        (status = 404, description = "Pool category does not exist"),
+        (status = 409, description = "Version is outdated"),
+        (status = 409, description = "Name is used by an existing pool category"),
+        (status = 422, description = "Name is invalid"),
+        (status = 422, description = "Color is invalid"),
     ),
 )]
 async fn update(
@@ -315,10 +315,10 @@ async fn set_default(
     request_body = DeleteBody,
     responses(
         (status = 200, body = ()),
-        (status = 400, description = "Pool category is the default category"),
         (status = 403, description = "Privileges are too low"),
         (status = 404, description = "Pool category does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 409, description = "Version is outdated"),
+        (status = 422, description = "Pool category is the default category"),
     ),
 )]
 async fn delete(

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -95,7 +95,7 @@ async fn get(
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 struct PoolCategoryCreateBody {
-    /// Category name.
+    /// Category name. Must match `pool_category_name_regex` from server's configuration.
     name: SmallString,
     /// Category color.
     color: SmallString,
@@ -156,7 +156,7 @@ async fn create(
 struct PoolCategoryUpdateBody {
     /// Resource version. See [versioning](#Versioning).
     version: DateTime,
-    /// New category name.
+    /// New category name. Must match `pool_category_name_regex` from server's configuration.
     name: Option<SmallString>,
     /// New category color.
     color: Option<SmallString>,

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -30,8 +30,8 @@ pub fn routes() -> OpenApiRouter<AppState> {
 ///
 /// Doesn't use paging.
 #[utoipa::path(
-    get, 
-    path = "/pool-categories", 
+    get,
+    path = "/pool-categories",
     tag = POOL_CATEGORY_TAG,
     params(ResourceParams),
     responses(
@@ -57,8 +57,8 @@ async fn list(
 
 /// Retrieves information about an existing pool category.
 #[utoipa::path(
-    get, 
-    path = "/pool-category/{name}", 
+    get,
+    path = "/pool-category/{name}",
     tag = POOL_CATEGORY_TAG,
     params(
         ("name" = String, Path, description = "Pool category name"),
@@ -106,8 +106,8 @@ struct PoolCategoryCreateBody {
 /// Name must match `pool_category_name_regex` from server's configuration.
 /// Names are case insensitive.
 #[utoipa::path(
-    post, 
-    path = "/pool-categories", 
+    post,
+    path = "/pool-categories",
     tag = POOL_CATEGORY_TAG,
     params(ResourceParams),
     request_body = PoolCategoryCreateBody,
@@ -168,8 +168,8 @@ struct PoolCategoryUpdateBody {
 /// Names are case insensitive. All fields except `version` are optional -
 /// update concerns only provided fields.
 #[utoipa::path(
-    put, 
-    path = "/pool-category/{name}", 
+    put,
+    path = "/pool-category/{name}",
     tag = POOL_CATEGORY_TAG,
     params(
         ("name" = String, Path, description = "Pool category name"),
@@ -228,8 +228,8 @@ async fn update(
 ///
 /// All new pools created manually or automatically will have this category.
 #[utoipa::path(
-    put, 
-    path = "/pool-category/{name}/default", 
+    put,
+    path = "/pool-category/{name}/default",
     tag = POOL_CATEGORY_TAG,
     params(
         ("name" = String, Path, description = "Pool category name"),
@@ -303,8 +303,8 @@ async fn set_default(
 ///
 /// Pools belonging to this category will be moved to the default category.
 #[utoipa::path(
-    delete, 
-    path = "/pool-category/{name}", 
+    delete,
+    path = "/pool-category/{name}",
     tag = POOL_CATEGORY_TAG,
     params(
         ("name" = String, Path, description = "Pool category name"),

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -725,7 +725,7 @@ async fn create(
 /// set to truthy value, the uploader name won't be recorded (privilege
 /// verification still applies; it's possible to disallow anonymous uploads
 /// completely from config.) For details on how to pass `content` and
-/// `thumbnail`, see [file uploads](#File-Uploads).
+/// `thumbnail`, see [file uploads](#Upload).
 #[utoipa::path(
     post,
     path = "/posts",
@@ -1106,7 +1106,7 @@ async fn update(
 /// `flag` can be either `loop` to enable looping for video posts or `sound` to
 /// indicate sound. Sending empty `thumbnail` will reset the post thumbnail to
 /// default. For details how to pass `content` and `thumbnail`, see
-/// [file uploads](#File-Uploads). All fields except `version` are optional -
+/// [file uploads](#Upload). All fields except `version` are optional -
 /// update concerns only provided fields.
 #[utoipa::path(
     put,

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::POST_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, JsonOrMultipart, Path, Query};
-use crate::api::{DeleteBody, MergeBody, POST_TAG, PageParams, PagedResponse, RatingBody, ResourceParams, error};
+use crate::api::{DeleteBody, MergeBody, PageParams, PagedResponse, RatingBody, ResourceParams, error};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::Config;
@@ -554,6 +555,7 @@ async fn create_handler(
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 struct PostMergeBody {
+    #[schema(inline)]
     #[serde(flatten)]
     post_info: MergeBody<i64>,
     replace_content: bool,

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -219,7 +219,8 @@ async fn list(
     responses(
         (status = 200, body = PostInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The post does not exist"),
+        (status = 403, description = "Post is hidden"),
+        (status = 404, description = "Post does not exist"),
     ),
 )]
 async fn get(
@@ -260,7 +261,8 @@ struct PostNeighbors {
     responses(
         (status = 200, body = PostNeighbors),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The post does not exist"),
+        (status = 403, description = "Post is hidden"),
+        (status = 404, description = "Post does not exist"),
     ),
 )]
 async fn get_neighbors(
@@ -407,8 +409,8 @@ struct FeatureBody {
     request_body = FeatureBody,
     responses(
         (status = 200, body = PostInfo),
-        (status = 400, description = "Trying to feature a post that is currently featured"),
         (status = 403, description = "Privileges are too low"),
+        (status = 409, description = "Trying to feature a post that is currently featured"),
     ),
 )]
 async fn feature(
@@ -564,6 +566,7 @@ struct ReverseSearchResponse {
     ),
     responses(
         (status = 200, body = ReverseSearchResponse),
+        (status = 400, description = "Reverse search content is missing"),
         (status = 403, description = "Privileges are too low"),
     ),
 )]
@@ -753,12 +756,13 @@ struct PostCreateBody {
     ),
     responses(
         (status = 200, body = PostInfo),
-        (status = 400, description = "Tags have invalid names"),
-        (status = 400, description = "Safety is invalid"),
-        (status = 400, description = "Notes are invalid"),
-        (status = 400, description = "Flags are invalid"),
-        (status = 400, description = "Relations refer to non-existing posts"),
+        (status = 400, description = "Post content is missing"),
         (status = 403, description = "Privileges are too low"),
+        (status = 404, description = "Relations refer to non-existing posts"),
+        (status = 422, description = "A Tag has an invalid name"),
+        (status = 422, description = "Safety is invalid"),
+        (status = 422, description = "Notes are invalid"),
+        (status = 422, description = "Flags are invalid"),
     ),
 )]
 async fn create(
@@ -809,10 +813,10 @@ struct PostMergeBody {
     request_body = PostMergeBody,
     responses(
         (status = 200, body = PostInfo),
-        (status = 400, description = "The source post is the same as the target post"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The source or target post does not exist"),
-        (status = 409, description = "The version of either post is outdated"),
+        (status = 404, description = "Source or target post does not exist"),
+        (status = 409, description = "Version of either post is outdated"),
+        (status = 422, description = "Source post is the same as the target post"),
     ),
 )]
 async fn merge(
@@ -910,9 +914,9 @@ async fn favorite(
     request_body = RatingBody,
     responses(
         (status = 200, body = PostInfo),
-        (status = 400, description = "Score is invalid"),
         (status = 403, description = "Privileges are too low"),
         (status = 404, description = "Post does not exist"),
+        (status = 422, description = "Score is invalid"),
     ),
 )]
 async fn rate(
@@ -1139,14 +1143,14 @@ struct PostUpdateBody {
     ),
     responses(
         (status = 200, body = PostInfo),
-        (status = 400, description = "Tags have invalid names"),
-        (status = 400, description = "Safety is invalid"),
-        (status = 400, description = "Notes are invalid"),
-        (status = 400, description = "Flags are invalid"),
-        (status = 400, description = "Relations refer to non-existing posts"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The post does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Post does not exist"),
+        (status = 404, description = "Relations refer to non-existing posts"),
+        (status = 409, description = "Version is outdated"),
+        (status = 422, description = "A tag has an invalid name"),
+        (status = 422, description = "Safety is invalid"),
+        (status = 422, description = "Notes are invalid"),
+        (status = 422, description = "Flags are invalid"),
     ),
 )]
 async fn update(
@@ -1185,8 +1189,8 @@ async fn update(
     responses(
         (status = 200, body = Object),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The post does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Post does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn delete(

--- a/server/src/api/snapshot.rs
+++ b/server/src/api/snapshot.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::SNAPSHOT_TAG;
 use crate::api::error::ApiResult;
 use crate::api::extract::{Json, Query};
-use crate::api::{PageParams, PagedResponse, SNAPSHOT_TAG};
+use crate::api::{PageParams, PagedResponse};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::resource::snapshot::SnapshotInfo;

--- a/server/src/api/snapshot.rs
+++ b/server/src/api/snapshot.rs
@@ -1,7 +1,7 @@
 use crate::api::doc::SNAPSHOT_TAG;
 use crate::api::error::ApiResult;
 use crate::api::extract::{Json, Query};
-use crate::api::{PageParams, PagedResponse};
+use crate::api::{PageParams, PagedResponse, ResourceParams};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::resource::snapshot::SnapshotInfo;
@@ -46,7 +46,7 @@ const MAX_SNAPSHOTS_PER_PAGE: i64 = 1000;
     get,
     path = "/snapshots",
     tag = SNAPSHOT_TAG,
-    params(PageParams),
+    params(ResourceParams, PageParams),
     responses(
         (status = 200, body = PagedResponse<SnapshotInfo>),
         (status = 403, description = "Privileges are too low"),
@@ -55,20 +55,21 @@ const MAX_SNAPSHOTS_PER_PAGE: i64 = 1000;
 async fn list(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
-    Query(params): Query<PageParams>,
+    Query(resource): Query<ResourceParams>,
+    Query(page): Query<PageParams>,
 ) -> ApiResult<Json<PagedResponse<SnapshotInfo>>> {
     api::verify_privilege(client, state.config.privileges().snapshot_list)?;
 
-    let offset = params.offset.unwrap_or(0);
-    let limit = std::cmp::min(params.limit.get(), MAX_SNAPSHOTS_PER_PAGE);
-    let fields = resource::create_table(params.fields()).map_err(Box::from)?;
+    let offset = page.offset.unwrap_or(0);
+    let limit = std::cmp::min(page.limit.get(), MAX_SNAPSHOTS_PER_PAGE);
+    let fields = resource::create_table(resource.fields()).map_err(Box::from)?;
     state.get_connection()?.transaction(|conn| {
-        let mut query_builder = QueryBuilder::new(client, params.criteria())?;
+        let mut query_builder = QueryBuilder::new(client, resource.criteria())?;
         query_builder.set_offset_and_limit(offset, limit);
 
         let (total, selected_snapshots) = query_builder.list(conn)?;
         Ok(Json(PagedResponse {
-            query: params.into_query(),
+            query: resource.query,
             offset,
             limit,
             total,

--- a/server/src/api/snapshot.rs
+++ b/server/src/api/snapshot.rs
@@ -19,7 +19,39 @@ pub fn routes() -> OpenApiRouter<AppState> {
 
 const MAX_SNAPSHOTS_PER_PAGE: i64 = 1000;
 
-#[utoipa::path(get, path = "/snapshots", tag = SNAPSHOT_TAG)]
+/// Lists recent resource snapshots.
+///
+/// **Anonymous tokens**
+///
+/// Not supported.
+///
+/// **Named tokens**
+///
+/// | Key            | Description                                                      |
+/// | -------------- | ---------------------------------------------------------------- |
+/// | `type`         | involving given resource type                                    |
+/// | `id`           | involving given resource id                                      |
+/// | `date`, `time` | created at given date                                            |
+/// | `operation`    | `modified`, `created`, `deleted` or `merged`                     |
+/// | `user`         | name of the user that created given snapshot (accepts wildcards) |
+///
+/// **Sort style tokens**
+///
+/// None. The snapshots are always sorted by creation time.
+///
+/// **Special tokens**
+///
+/// None.
+#[utoipa::path(
+    get,
+    path = "/snapshots",
+    tag = SNAPSHOT_TAG,
+    params(PageParams),
+    responses(
+        (status = 200, body = PagedResponse<SnapshotInfo>),
+        (status = 403, description = "Privileges are too low"),
+    ),
+)]
 async fn list(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,

--- a/server/src/api/snapshot.rs
+++ b/server/src/api/snapshot.rs
@@ -1,23 +1,24 @@
 use crate::api::error::ApiResult;
 use crate::api::extract::{Json, Query};
-use crate::api::{PageParams, PagedResponse};
+use crate::api::{PageParams, PagedResponse, SNAPSHOT_TAG};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::resource::snapshot::SnapshotInfo;
 use crate::search::Builder;
 use crate::search::snapshot::QueryBuilder;
 use crate::{api, resource};
-use axum::extract::State;
-use axum::{Extension, Router, routing};
+use axum::extract::{Extension, State};
 use diesel::Connection;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
 
-pub fn routes() -> Router<AppState> {
-    Router::new().route("/snapshots", routing::get(list))
+pub fn routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(list))
 }
 
 const MAX_SNAPSHOTS_PER_PAGE: i64 = 1000;
 
-/// See [listing-snapshots](https://github.com/liamw1/oxibooru/blob/master/docs/API.md#listing-snapshots)
+#[utoipa::path(get, path = "/snapshots", tag = SNAPSHOT_TAG)]
 async fn list(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,

--- a/server/src/api/tag.rs
+++ b/server/src/api/tag.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::TAG_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::{DeleteBody, MergeBody, PageParams, PagedResponse, ResourceParams, TAG_TAG};
+use crate::api::{DeleteBody, MergeBody, PageParams, PagedResponse, ResourceParams};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::Config;

--- a/server/src/api/tag.rs
+++ b/server/src/api/tag.rs
@@ -124,7 +124,8 @@ async fn list(
     responses(
         (status = 200, body = TagInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag does not exist"),
+        (status = 403, description = "Tag is hidden"),
+        (status = 404, description = "Tag does not exist"),
     ),
 )]
 async fn get(
@@ -177,6 +178,8 @@ struct TagSiblings {
     responses(
         (status = 200, body = TagSiblings),
         (status = 403, description = "Privileges are too low"),
+        (status = 403, description = "Tag is hidden"),
+        (status = 404, description = "Tag does not exist"),
     ),
 )]
 async fn get_siblings(
@@ -259,12 +262,12 @@ struct TagCreateBody {
     request_body = TagCreateBody,
     responses(
         (status = 200, body = TagInfo),
-        (status = 400, description = "Any name is used by an existing tag"),
-        (status = 400, description = "Any name, implication or suggestion is invalid"),
-        (status = 400, description = "Category is invalid"),
-        (status = 400, description = "No name was specified"),
-        (status = 400, description = "Implications or suggestions create a cyclic dependency"),
         (status = 403, description = "Privileges are too low"),
+        (status = 409, description = "Any name is used by an existing tag"),
+        (status = 422, description = "No name was specified"),
+        (status = 422, description = "Category is missing or invalid"),
+        (status = 422, description = "Any name, implication or suggestion is invalid"),
+        (status = 422, description = "Implications or suggestions create a cyclic dependency"),
     ),
 )]
 async fn create(
@@ -342,10 +345,10 @@ async fn create(
     request_body = MergeBody<SmallString>,
     responses(
         (status = 200, body = TagInfo),
-        (status = 400, description = "The source tag is the same as the target tag"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The source or target tag does not exist"),
-        (status = 409, description = "The version of either tag is outdated"),
+        (status = 404, description = "Source or target tag does not exist"),
+        (status = 409, description = "Version of either tag is outdated"),
+        (status = 422, description = "Source tag is the same as the target tag"),
     ),
 )]
 async fn merge(
@@ -424,13 +427,13 @@ struct TagUpdateBody {
     request_body = TagUpdateBody,
     responses(
         (status = 200, body = TagInfo),
-        (status = 400, description = "Any name is used by an existing tag"),
-        (status = 400, description = "Any name, implication or suggestion name is invalid"),
-        (status = 400, description = "Category is invalid"),
-        (status = 400, description = "Implications or suggestions create a cyclic dependency"),
         (status = 403, description = "Privileges are too low"),
         (status = 404, description = "The tag does not exist"),
         (status = 409, description = "The version is outdated"),
+        (status = 409, description = "Any name is used by an existing tag"),
+        (status = 422, description = "Category is invalid"),
+        (status = 422, description = "Any name, implication or suggestion name is invalid"),
+        (status = 422, description = "Implications or suggestions create a cyclic dependency"),
     ),
 )]
 async fn update(
@@ -524,10 +527,9 @@ async fn update(
     request_body = DeleteBody,
     responses(
         (status = 200, body = Object),
-        (status = 400, description = "The tag has usages"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Tag does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn delete(

--- a/server/src/api/tag.rs
+++ b/server/src/api/tag.rs
@@ -142,7 +142,7 @@ async fn get_siblings(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateBody {
+struct TagCreateBody {
     category: SmallString,
     description: Option<LargeString>,
     names: Vec<SmallString>,
@@ -155,7 +155,7 @@ async fn create(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<TagCreateBody>,
 ) -> ApiResult<Json<TagInfo>> {
     api::verify_privilege(client, state.config.privileges().tag_create)?;
 
@@ -254,7 +254,7 @@ async fn merge(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct UpdateBody {
+struct TagUpdateBody {
     version: DateTime,
     category: Option<SmallString>,
     description: Option<LargeString>,
@@ -269,7 +269,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path(name): Path<SmallString>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<TagUpdateBody>,
 ) -> ApiResult<Json<TagInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/tag_category.rs
+++ b/server/src/api/tag_category.rs
@@ -69,7 +69,8 @@ async fn list(
     responses(
         (status = 200, body = TagCategoryInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag category does not exist"),
+        (status = 403, description = "Tag category is hidden"),
+        (status = 404, description = "Tag category does not exist"),
     ),
 )]
 async fn get(
@@ -112,10 +113,10 @@ struct TagCategoryCreateBody {
     request_body = TagCategoryCreateBody,
     responses(
         (status = 200, body = TagCategoryInfo),
-        (status = 400, description = "The name is invalid or missing"),
-        (status = 400, description = "The color is invalid or missing"),
         (status = 403, description = "Privileges are too low"),
-        (status = 409, description = "The name is used by an existing tag category"),
+        (status = 409, description = "Name is used by an existing tag category"),
+        (status = 422, description = "Name is invalid or missing"),
+        (status = 422, description = "Color is invalid or missing"),
     ),
 )]
 async fn create(
@@ -181,12 +182,12 @@ struct TagCategoryUpdateBody {
     request_body = TagCategoryUpdateBody,
     responses(
         (status = 200, body = TagCategoryInfo),
-        (status = 400, description = "The name is invalid"),
-        (status = 400, description = "The color is invalid"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag category does not exist"),
-        (status = 409, description = "The version is outdated"),
-        (status = 409, description = "The name is used by an existing tag category"),
+        (status = 404, description = "Tag category does not exist"),
+        (status = 409, description = "Version is outdated"),
+        (status = 409, description = "Name is used by an existing tag category"),
+        (status = 422, description = "Name is invalid"),
+        (status = 422, description = "Color is invalid"),
     ),
 )]
 async fn update(
@@ -248,7 +249,7 @@ async fn update(
     responses(
         (status = 200, body = TagCategoryInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag category does not exist"),
+        (status = 404, description = "Tag category does not exist"),
     ),
 )]
 async fn set_default(
@@ -321,10 +322,10 @@ async fn set_default(
     request_body = DeleteBody,
     responses(
         (status = 200, body = Object),
-        (status = 400, description = "The tag category is the default category"),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The tag category does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "Tag category does not exist"),
+        (status = 409, description = "Version is outdated"),
+        (status = 422, description = "Tag category is the default category"),
     ),
 )]
 async fn delete(

--- a/server/src/api/tag_category.rs
+++ b/server/src/api/tag_category.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::TAG_CATEGORY_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::{DeleteBody, ResourceParams, TAG_CATEGORY_TAG, UnpagedResponse, error};
+use crate::api::{DeleteBody, ResourceParams, UnpagedResponse, error};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::{Config, RegexType};

--- a/server/src/api/tag_category.rs
+++ b/server/src/api/tag_category.rs
@@ -64,7 +64,7 @@ async fn get(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateBody {
+struct TagCategoryCreateBody {
     order: i32,
     name: SmallString,
     color: SmallString,
@@ -75,7 +75,7 @@ async fn create(
     State(state): State<AppState>,
     Extension(client): Extension<Client>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<TagCategoryCreateBody>,
 ) -> ApiResult<Json<TagCategoryInfo>> {
     api::verify_privilege(client, state.config.privileges().tag_category_create)?;
     api::verify_matches_regex(&state.config, &body.name, RegexType::TagCategory)?;
@@ -106,7 +106,7 @@ async fn create(
 
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct UpdateBody {
+struct TagCategoryUpdateBody {
     version: DateTime,
     order: Option<i32>,
     name: Option<SmallString>,
@@ -119,7 +119,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path(name): Path<SmallString>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<TagCategoryUpdateBody>,
 ) -> ApiResult<Json<TagCategoryInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/upload.rs
+++ b/server/src/api/upload.rs
@@ -1,7 +1,8 @@
+use crate::api;
+use crate::api::doc::UPLOAD_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::Json;
 use crate::api::extract::JsonOrMultipart;
-use crate::api::{self, UPLOAD_TAG};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::config::Config;

--- a/server/src/api/upload.rs
+++ b/server/src/api/upload.rs
@@ -23,8 +23,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
 
 /// Request body for uploading a temporary file.
 #[derive(Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct UploadBody {
     /// URL to fetch content from.
     content_url: Url,

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::USER_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, JsonOrMultipart, Path, Query};
-use crate::api::{DeleteBody, PageParams, PagedResponse, ResourceParams, USER_TAG, error};
+use crate::api::{DeleteBody, PageParams, PagedResponse, ResourceParams, error};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::auth::password;

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -261,7 +261,7 @@ async fn create(
 /// server's configuration, respectively. Email address, rank and avatar fields
 /// are optional. Avatar style can be either `gravatar` or `manual`. `manual`
 /// avatar style requires client to pass also `avatar` file - see
-/// [file uploads](#tag/File-Uploads) for details. If the rank is empty and the
+/// [file uploads](#Upload) for details. If the rank is empty and the
 /// user happens to be the first user ever created, become an administrator,
 /// whereas subsequent users will be given the rank indicated by `default_rank`
 /// in the server's configuration.
@@ -470,9 +470,9 @@ async fn update(
 /// Names and passwords must match `user_name_regex` and `password_regex` from
 /// server's configuration, respectively. Avatar style can be either `gravatar`
 /// or `manual`. `manual` avatar style requires client to pass also `avatar`
-/// file - see [file uploads](#tag/File-Uploads) for details. All fields except
+/// file - see [file uploads](#Upload) for details. All fields except
 /// `version` are optional - update concerns only provided fields. To update
-/// last login time, see [authentication](#tag/Authentication).
+/// last login time, see [authentication](#Authentication).
 #[utoipa::path(
     put,
     path = "/user/{name}",

--- a/server/src/api/user.rs
+++ b/server/src/api/user.rs
@@ -129,7 +129,7 @@ async fn list(
     responses(
         (status = 200, body = UserInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
+        (status = 404, description = "User does not exist"),
     ),
 )]
 async fn get(
@@ -288,14 +288,14 @@ struct UserCreateBody {
     ),
     responses(
         (status = 200, body = UserInfo),
-        (status = 400, description = "User name is invalid"),
-        (status = 400, description = "Password is invalid"),
-        (status = 400, description = "Email is invalid"),
-        (status = 400, description = "Rank is invalid"),
         (status = 400, description = "Avatar is missing for manual avatar style"),
         (status = 403, description = "Privileges are too low"),
         (status = 403, description = "Trying to set rank higher than own rank"),
         (status = 409, description = "A user with such name already exists"),
+        (status = 422, description = "User name is missing or invalid"),
+        (status = 422, description = "Password is missing or invalid"),
+        (status = 422, description = "Email is invalid"),
+        (status = 422, description = "Rank is invalid"),
     ),
 )]
 async fn create(
@@ -503,16 +503,16 @@ struct UserUpdateBody {
     ),
     responses(
         (status = 200, body = UserInfo),
-        (status = 400, description = "User name is invalid"),
-        (status = 400, description = "Password is invalid"),
-        (status = 400, description = "Email is invalid"),
-        (status = 400, description = "Rank is invalid"),
         (status = 400, description = "Avatar is missing for manual avatar style"),
         (status = 403, description = "Privileges are too low"),
         (status = 403, description = "Trying to set rank higher than own rank"),
-        (status = 404, description = "The user does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "User does not exist"),
+        (status = 409, description = "Version is outdated"),
         (status = 409, description = "A user with new name already exists"),
+        (status = 422, description = "User name is invalid"),
+        (status = 422, description = "Password is invalid"),
+        (status = 422, description = "Email is invalid"),
+        (status = 422, description = "Rank is invalid"),
     ),
 )]
 async fn update(
@@ -550,8 +550,8 @@ async fn update(
     responses(
         (status = 200, body = Object),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "User does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn delete(

--- a/server/src/api/user_token.rs
+++ b/server/src/api/user_token.rs
@@ -1,6 +1,7 @@
+use crate::api::doc::USER_TOKEN_TAG;
 use crate::api::error::{ApiError, ApiResult};
 use crate::api::extract::{Json, Path, Query};
-use crate::api::{ResourceParams, USER_TOKEN_TAG, UnpagedResponse};
+use crate::api::{ResourceParams, UnpagedResponse};
 use crate::app::AppState;
 use crate::auth::Client;
 use crate::model::enums::{AvatarStyle, ResourceType};

--- a/server/src/api/user_token.rs
+++ b/server/src/api/user_token.rs
@@ -73,7 +73,7 @@ async fn list(
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-struct CreateBody {
+struct UserTokenCreateBody {
     enabled: bool,
     note: Option<String>,
     expiration_time: Option<DateTime>,
@@ -85,7 +85,7 @@ async fn create(
     Extension(client): Extension<Client>,
     Path(username): Path<SmallString>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<CreateBody>,
+    Json(body): Json<UserTokenCreateBody>,
 ) -> ApiResult<Json<UserTokenInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 
@@ -133,7 +133,7 @@ async fn create(
 #[derive(Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
-struct UpdateBody {
+struct UserTokenUpdateBody {
     version: DateTime,
     enabled: Option<bool>,
     note: Option<LargeString>,
@@ -147,7 +147,7 @@ async fn update(
     Extension(client): Extension<Client>,
     Path((username, token)): Path<(String, Uuid)>,
     Query(params): Query<ResourceParams>,
-    Json(body): Json<UpdateBody>,
+    Json(body): Json<UserTokenUpdateBody>,
 ) -> ApiResult<Json<UserTokenInfo>> {
     let fields = resource::create_table(params.fields()).map_err(Box::from)?;
 

--- a/server/src/api/user_token.rs
+++ b/server/src/api/user_token.rs
@@ -44,7 +44,7 @@ pub fn routes() -> OpenApiRouter<AppState> {
     responses(
         (status = 200, body = UnpagedResponse<UserTokenInfo>),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
+        (status = 404, description = "User does not exist"),
     ),
 )]
 async fn list(
@@ -112,7 +112,7 @@ struct UserTokenCreateBody {
     responses(
         (status = 200, body = UserTokenInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
+        (status = 404, description = "User does not exist"),
     ),
 )]
 async fn create(
@@ -196,9 +196,9 @@ struct UserTokenUpdateBody {
     responses(
         (status = 200, body = UserTokenInfo),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
-        (status = 404, description = "The user token does not exist"),
-        (status = 409, description = "The version is outdated"),
+        (status = 404, description = "User does not exist"),
+        (status = 404, description = "User token does not exist"),
+        (status = 409, description = "Version is outdated"),
     ),
 )]
 async fn update(
@@ -268,8 +268,8 @@ async fn update(
     responses(
         (status = 200, body = Object),
         (status = 403, description = "Privileges are too low"),
-        (status = 404, description = "The user does not exist"),
-        (status = 404, description = "The token does not exist"),
+        (status = 404, description = "User does not exist"),
+        (status = 404, description = "Token does not exist"),
     ),
 )]
 async fn delete(

--- a/server/src/api/user_token.rs
+++ b/server/src/api/user_token.rs
@@ -87,11 +87,10 @@ async fn list(
 
 /// Request body for creating a user token.
 #[derive(Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct UserTokenCreateBody {
-    /// Whether the token is enabled.
-    enabled: bool,
+    /// Whether the token is enabled. Defaults to `true` if not present.
+    enabled: Option<bool>,
     /// Optional note describing the token's purpose.
     note: Option<String>,
     /// Optional expiration time for the token.
@@ -156,7 +155,7 @@ async fn create(
             id: Uuid::new_v4(),
             user_id,
             note: body.note.as_deref(),
-            enabled: body.enabled,
+            enabled: body.enabled.unwrap_or(true),
             expiration_time: body.expiration_time,
         }
         .insert_into(user_token::table)
@@ -168,8 +167,7 @@ async fn create(
 
 /// Request body for updating a user token.
 #[derive(Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct UserTokenUpdateBody {
     /// Resource version. See [versioning](#Versioning).
     version: DateTime,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -176,18 +176,17 @@ pub struct PrivilegeConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all(serialize = "camelCase"))]
+#[schema(rename_all = "camelCase")] // ToSchema doesn't detect serde(rename_all(serialize = ...))
+#[serde(deny_unknown_fields, rename_all(serialize = "camelCase"))]
 pub struct PublicConfig {
     pub name: SmallString,
     pub default_user_rank: UserRank,
     pub enable_safety: bool,
     pub contact_email: Option<SmallString>,
-    #[serde(skip_deserializing)]
+    #[serde(default)]
     pub can_send_mails: bool,
-    #[schema(value_type = String)]
-    #[serde(with = "serde_regex")]
-    #[serde(rename(serialize = "userNameRegex"))]
+    #[schema(rename = "userNameRegex", value_type = String)]
+    #[serde(rename(serialize = "userNameRegex"), with = "serde_regex")]
     pub username_regex: Regex,
     #[schema(value_type = String)]
     #[serde(with = "serde_regex")]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use strum::Display;
 use url::Url;
+use utoipa::ToSchema;
 
 #[derive(Debug, Display, Clone, Copy)]
 #[strum(serialize_all = "lowercase")]
@@ -69,7 +70,7 @@ impl AnonymousPreferences {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 pub struct PrivilegeConfig {
     pub user_create_self: UserRank,
     pub user_create_any: UserRank,
@@ -174,7 +175,7 @@ pub struct PrivilegeConfig {
     pub upload_use_downloader: UserRank,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct PublicConfig {
@@ -184,13 +185,17 @@ pub struct PublicConfig {
     pub contact_email: Option<SmallString>,
     #[serde(skip_deserializing)]
     pub can_send_mails: bool,
+    #[schema(value_type = String)]
     #[serde(with = "serde_regex")]
     #[serde(rename(serialize = "userNameRegex"))]
     pub username_regex: Regex,
+    #[schema(value_type = String)]
     #[serde(with = "serde_regex")]
     pub password_regex: Regex,
+    #[schema(value_type = String)]
     #[serde(with = "serde_regex")]
     pub tag_name_regex: Regex,
+    #[schema(value_type = String)]
     #[serde(with = "serde_regex")]
     pub tag_category_name_regex: Regex,
     pub privileges: PrivilegeConfig,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -185,16 +185,16 @@ pub struct PublicConfig {
     pub contact_email: Option<SmallString>,
     #[serde(default)]
     pub can_send_mails: bool,
-    #[schema(rename = "userNameRegex", value_type = String)]
+    #[schema(rename = "userNameRegex", value_type = String, format = Regex)]
     #[serde(rename(serialize = "userNameRegex"), with = "serde_regex")]
     pub username_regex: Regex,
-    #[schema(value_type = String)]
+    #[schema(value_type = String, format = Regex)]
     #[serde(with = "serde_regex")]
     pub password_regex: Regex,
-    #[schema(value_type = String)]
+    #[schema(value_type = String, format = Regex)]
     #[serde(with = "serde_regex")]
     pub tag_name_regex: Regex,
-    #[schema(value_type = String)]
+    #[schema(value_type = String, format = Regex)]
     #[serde(with = "serde_regex")]
     pub tag_category_name_regex: Regex,
     pub privileges: PrivilegeConfig,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::pedantic)]
-// Gives warnings on EnumTables
-#![allow(clippy::too_many_arguments)]
+// Gives warnings on derives
+#![allow(clippy::needless_for_each, clippy::large_stack_arrays, clippy::too_many_arguments)]
 // Gives warnings for integer casts in const context
 #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 // Option<Option<T>> is convenient for deserializing optional nullable JSON fields

--- a/server/src/model/enums.rs
+++ b/server/src/model/enums.rs
@@ -457,7 +457,7 @@ impl FromSql<SmallInt, Pg> for Score {
     }
 }
 
-#[derive(Debug, Clone, Copy, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize)]
+#[derive(Debug, Clone, Copy, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[diesel(sql_type = SmallInt)]
 #[repr(i16)]
@@ -482,7 +482,7 @@ impl FromSql<SmallInt, Pg> for ResourceOperation {
     }
 }
 
-#[derive(Debug, Display, Clone, Copy, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize)]
+#[derive(Debug, Display, Clone, Copy, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[diesel(sql_type = SmallInt)]

--- a/server/src/model/enums.rs
+++ b/server/src/model/enums.rs
@@ -11,7 +11,9 @@ use std::ops::{BitOr, BitOrAssign};
 use std::path::Path;
 use strum::{Display, EnumCount, EnumIter, EnumString, FromRepr, IntoEnumIterator, IntoStaticStr};
 use thiserror::Error;
-use utoipa::ToSchema;
+use utoipa::openapi::schema::{Schema, SchemaType};
+use utoipa::openapi::{ObjectBuilder, RefOr, Type};
+use utoipa::{PartialSchema, ToSchema};
 
 /// In general, the order of these enums should not be changed.
 /// They are encoded in the database as an integer, so changing
@@ -378,7 +380,7 @@ impl FromSql<SmallInt, Pg> for UserRank {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize_repr, Deserialize_repr, ToSchema)]
+#[derive(Debug, Default, Clone, Copy, Serialize_repr, Deserialize_repr)]
 #[repr(i16)]
 pub enum Rating {
     Dislike = -1,
@@ -393,6 +395,24 @@ impl From<Score> for Rating {
             Score::Dislike => Self::Dislike,
             Score::Like => Self::Like,
         }
+    }
+}
+
+impl ToSchema for Rating {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("Rating")
+    }
+}
+
+impl PartialSchema for Rating {
+    fn schema() -> RefOr<Schema> {
+        ObjectBuilder::new()
+            .schema_type(SchemaType::new(Type::Integer))
+            .description(Some("Rating value: -1 (dislike), 0 (none), or 1 (like)"))
+            .minimum(Some(-1))
+            .maximum(Some(1))
+            .examples([-1, 0, 1])
+            .into()
     }
 }
 

--- a/server/src/model/enums.rs
+++ b/server/src/model/enums.rs
@@ -57,7 +57,9 @@ impl FromSql<SmallInt, Pg> for AvatarStyle {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 #[diesel(sql_type = SmallInt)]
@@ -95,7 +97,19 @@ impl FromSql<SmallInt, Pg> for PostType {
 }
 
 #[derive(
-    Debug, Display, Copy, Clone, PartialEq, Eq, EnumString, FromRepr, AsExpression, FromSqlRow, Serialize, Deserialize,
+    Debug,
+    Display,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    EnumString,
+    FromRepr,
+    AsExpression,
+    FromSqlRow,
+    Serialize,
+    Deserialize,
+    ToSchema,
 )]
 #[diesel(sql_type = SmallInt)]
 #[repr(i16)]
@@ -219,6 +233,7 @@ impl FromSql<SmallInt, Pg> for MimeType {
     FromSqlRow,
     Serialize,
     Deserialize,
+    ToSchema,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
@@ -244,7 +259,7 @@ impl FromSql<SmallInt, Pg> for PostSafety {
     }
 }
 
-#[derive(Clone, Copy, EnumCount, EnumIter, EnumString, FromRepr, IntoStaticStr, Deserialize)]
+#[derive(Clone, Copy, EnumCount, EnumIter, EnumString, FromRepr, IntoStaticStr, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum PostFlag {
@@ -258,23 +273,20 @@ impl From<PostFlag> for u16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, AsExpression, FromSqlRow)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, AsExpression, FromSqlRow, ToSchema)]
 #[diesel(sql_type = SmallInt)]
-pub struct PostFlags {
-    flags: u16, // Bit mask of possible flags
-}
+#[schema(value_type = Vec<PostFlag>)]
+pub struct PostFlags(u16); // Bit mask of possible flags
 
 impl PostFlags {
     /// Constructs a new [`PostFlags`] with no flags set.
     pub const fn new() -> Self {
-        Self { flags: 0 }
+        Self(0)
     }
 
     /// Constructs a new [`PostFlags`] with a single `flag` set.
     pub const fn new_with(flag: PostFlag) -> Self {
-        Self {
-            flags: 1 << flag as u16,
-        }
+        Self(1 << flag as u16)
     }
 
     /// Constructs a new [`PostFlags`] with a set of `flags` set.
@@ -285,37 +297,33 @@ impl PostFlags {
 
 impl From<PostFlags> for u16 {
     fn from(value: PostFlags) -> Self {
-        value.flags
+        value.0
     }
 }
 
 impl<T: Into<u16>> BitOr<T> for PostFlags {
     type Output = Self;
     fn bitor(self, rhs: T) -> Self::Output {
-        Self {
-            flags: self.flags | rhs.into(),
-        }
+        Self(self.0 | rhs.into())
     }
 }
 
 impl<T: Into<u16>> BitOrAssign<T> for PostFlags {
     fn bitor_assign(&mut self, rhs: T) {
-        self.flags |= rhs.into();
+        self.0 |= rhs.into();
     }
 }
 
 impl ToSql<SmallInt, Pg> for PostFlags {
     fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
-        out.write_i16::<NetworkEndian>(self.flags as i16)?;
+        out.write_i16::<NetworkEndian>(self.0 as i16)?;
         Ok(IsNull::No)
     }
 }
 
 impl FromSql<SmallInt, Pg> for PostFlags {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
-        i16::from_sql(value).map(|database_value| Self {
-            flags: database_value.cast_unsigned(),
-        })
+        i16::from_sql(value).map(|database_value| Self(database_value.cast_unsigned()))
     }
 }
 
@@ -329,7 +337,7 @@ impl Serialize for PostFlags {
         let flags: Vec<&'static str> = PostFlag::iter()
             .filter(|&flag| {
                 let bit = flag as u16;
-                self.flags & (1 << bit) != 0 // Check if flag is set
+                self.0 & (1 << bit) != 0 // Check if flag is set
             })
             .map(Into::into)
             .collect();

--- a/server/src/model/enums.rs
+++ b/server/src/model/enums.rs
@@ -11,6 +11,7 @@ use std::ops::{BitOr, BitOrAssign};
 use std::path::Path;
 use strum::{Display, EnumCount, EnumIter, EnumString, FromRepr, IntoEnumIterator, IntoStaticStr};
 use thiserror::Error;
+use utoipa::ToSchema;
 
 /// In general, the order of these enums should not be changed.
 /// They are encoded in the database as an integer, so changing
@@ -28,7 +29,9 @@ pub struct ParseExtensionError {
 #[error("Cannot convert None to Score")]
 pub struct FromRatingError;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, FromRepr, AsExpression, FromSqlRow, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, FromRepr, AsExpression, FromSqlRow, Serialize, Deserialize, ToSchema,
+)]
 #[serde(rename_all = "lowercase")]
 #[diesel(sql_type = SmallInt)]
 #[repr(i16)]
@@ -346,6 +349,7 @@ impl Serialize for PostFlags {
     FromSqlRow,
     Serialize,
     Deserialize,
+    ToSchema,
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
@@ -374,7 +378,7 @@ impl FromSql<SmallInt, Pg> for UserRank {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, Default, Clone, Copy, Serialize_repr, Deserialize_repr, ToSchema)]
 #[repr(i16)]
 pub enum Rating {
     Dislike = -1,

--- a/server/src/resource/comment.rs
+++ b/server/src/resource/comment.rs
@@ -39,15 +39,8 @@ impl BoolFill for FieldTable<bool> {
 #[skip_serializing_none]
 #[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
-#[schema(examples(json!({
-    "id": 1,
-    "post_id": 9,
-    "text": "This is a comment",
-    "score": 12,
-    "user": null
-})))]
 pub struct CommentInfo {
-    /// Resource version. See [versioning](#/Versioning) for details.
+    /// Resource version. See [versioning](#Versioning) for details.
     pub version: Option<DateTime>, // TODO: Remove last_edit_time as it fills the same role as version here
     /// The comment identifier.
     pub id: Option<i64>,

--- a/server/src/resource/comment.rs
+++ b/server/src/resource/comment.rs
@@ -10,7 +10,9 @@ use crate::time::DateTime;
 use diesel::{BelongingToDsl, ExpressionMethods, Identifiable, PgConnection, QueryDsl, QueryResult, RunQueryDsl};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
 #[derive(Clone, Copy, EnumString, EnumTable)]
 #[strum(serialize_all = "camelCase")]
@@ -32,18 +34,37 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A comment under a post.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+#[schema(examples(json!({
+    "id": 1,
+    "post_id": 9,
+    "text": "This is a comment",
+    "score": 12,
+    "user": null
+})))]
 pub struct CommentInfo {
+    /// Resource version. See [versioning](#/Versioning) for details.
     pub version: Option<DateTime>, // TODO: Remove last_edit_time as it fills the same role as version here
+    /// The comment identifier.
     pub id: Option<i64>,
+    /// ID of the post the comment is for.
     pub post_id: Option<i64>,
+    /// The comment content. The client should render this as Markdown.
     pub text: Option<LargeString>,
+    /// Time the comment was created.
     pub creation_time: Option<DateTime>,
+    /// Time the comment was last edited.
     pub last_edit_time: Option<DateTime>,
+    /// A micro user resource for the comment author, or null if anonymous.
+    #[schema(nullable)]
     pub user: Option<Option<MicroUser>>,
+    /// The collective score (+1/-1 rating) of the comment.
     pub score: Option<i64>,
+    /// The score (+1/-1 rating) of the comment by the authenticated user.
     pub own_score: Option<Rating>,
 }
 

--- a/server/src/resource/pool.rs
+++ b/server/src/resource/pool.rs
@@ -70,7 +70,7 @@ pub struct PoolInfo {
     description: Option<LargeString>,
     /// Time the pool was created.
     creation_time: Option<DateTime>,
-    /// Time the pool was edited.
+    /// Time the pool was last edited.
     last_edit_time: Option<DateTime>,
     /// The name of the category the given pool belongs to.
     category: Option<SmallString>,

--- a/server/src/resource/pool.rs
+++ b/server/src/resource/pool.rs
@@ -16,14 +16,22 @@ use serde::Serialize;
 use serde_with::skip_serializing_none;
 use std::rc::Rc;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+/// A pool resource stripped down to `id`, `names`, `category`, `description` and `postCount` fields.
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MicroPool {
+    /// Resource version. See [versioning](#Versioning).
     pub id: i64,
+    /// List of pool names (aliases).
+    #[schema(value_type = Vec<SmallString>)]
     pub names: Rc<[SmallString]>,
+    /// The name of the category the given pool belongs to.
     pub category: SmallString,
+    /// The pool description (instructions how to use, history etc.). The client should render it as Markdown.
     pub description: LargeString,
+    /// The number of posts the pool has.
     pub post_count: i64,
 }
 

--- a/server/src/resource/pool.rs
+++ b/server/src/resource/pool.rs
@@ -14,6 +14,7 @@ use diesel::{
 };
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use std::rc::Rc;
 use strum::{EnumString, EnumTable};
 use utoipa::ToSchema;
@@ -55,18 +56,29 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// An ordered list of posts, with a description and category.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PoolInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The pool identifier.
     id: Option<i64>,
+    /// The pool description (instructions how to use, history etc.). The client should render it as Markdown.
     description: Option<LargeString>,
+    /// Time the pool was created.
     creation_time: Option<DateTime>,
+    /// Time the pool was edited.
     last_edit_time: Option<DateTime>,
+    /// The name of the category the given pool belongs to.
     category: Option<SmallString>,
+    /// A list of pool names (aliases).
     names: Option<Vec<SmallString>>,
+    /// An ordered list of posts. Posts are ordered by insertion by default.
     posts: Option<Vec<MicroPost>>,
+    /// The number of posts the pool has.
     post_count: Option<i64>,
 }
 

--- a/server/src/resource/pool_category.rs
+++ b/server/src/resource/pool_category.rs
@@ -6,7 +6,9 @@ use crate::time::DateTime;
 use diesel::{PgConnection, QueryDsl, QueryResult, RunQueryDsl, SelectableHelper};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
 #[derive(Clone, Copy, EnumString, EnumTable)]
 #[strum(serialize_all = "camelCase")]
@@ -24,13 +26,22 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A single pool category. The primary purpose of pool categories is to distinguish
+/// certain pool types (such as series, relations etc.), which improves user
+/// experience.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct PoolCategoryInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The category name.
     name: Option<SmallString>,
+    /// The category color.
     color: Option<SmallString>,
+    /// How many pools is the given category used with.
     usages: Option<i64>,
+    /// Whether the pool category is the default one.
     default: Option<bool>,
 }
 

--- a/server/src/resource/post.rs
+++ b/server/src/resource/post.rs
@@ -168,7 +168,7 @@ pub struct PostInfo {
     description: Option<LargeString>,
     /// Time the tag was created.
     creation_time: Option<DateTime>,
-    /// Time the tag was edited.
+    /// Time the tag was last edited.
     last_edit_time: Option<DateTime>,
     /// Where the post content is located.
     content_url: Option<String>,

--- a/server/src/resource/post.rs
+++ b/server/src/resource/post.rs
@@ -36,7 +36,6 @@ use utoipa::ToSchema;
 #[serde(deny_unknown_fields)]
 pub struct Note {
     #[serde(skip)]
-    #[schema(ignore)]
     id: i64,
     /// Where to draw the annotation. Each point must have coordinates within 0 to 1.
     /// For example, `[[0,0],[0,1],[1,1],[1,0]]` will draw the annotation on the whole post,

--- a/server/src/resource/snapshot.rs
+++ b/server/src/resource/snapshot.rs
@@ -240,6 +240,7 @@ impl BoolFill for FieldTable<bool> {
 #[skip_serializing_none]
 #[derive(Serialize, ToSchema)]
 pub struct SnapshotInfo {
+    #[schema(nullable)]
     user: Option<Option<MicroUser>>,
     operation: Option<ResourceOperation>,
     #[serde(rename(serialize = "type"))]

--- a/server/src/resource/snapshot.rs
+++ b/server/src/resource/snapshot.rs
@@ -57,8 +57,7 @@ impl BoolFill for FieldTable<bool> {
 ///     | `"pool"`          | pool ID                          |
 ///     | `"pool_category"` | pool category name at given time |
 ///
-/// - `<issuer>`: a [micro user resource](#micro-user) representing the user who
-///     has made the change.
+/// - `<issuer>`: the user who made the change.
 ///
 /// - `<data>`: the snapshot data, of which content depends on the `<operation>`.
 ///    More explained later.
@@ -112,8 +111,6 @@ impl BoolFill for FieldTable<bool> {
 ///         "featured": false
 ///     }
 ///     ```
-///     
-///     `<note>`s are serialized the same way as [note resources](#note).
 ///
 /// - Pool category snapshot data (`<resource-type> = "pool_category"`)
 ///

--- a/server/src/resource/snapshot.rs
+++ b/server/src/resource/snapshot.rs
@@ -240,9 +240,9 @@ pub struct SnapshotInfo {
     #[schema(nullable)]
     user: Option<Option<MicroUser>>,
     operation: Option<ResourceOperation>,
-    #[serde(rename(serialize = "type"))]
+    #[serde(rename = "type")]
     resource_type: Option<ResourceType>,
-    #[serde(rename(serialize = "id"))]
+    #[serde(rename = "id")]
     resource_id: Option<SmallString>,
     data: Option<Value>,
     time: Option<DateTime>,

--- a/server/src/resource/snapshot.rs
+++ b/server/src/resource/snapshot.rs
@@ -11,7 +11,9 @@ use diesel::{ExpressionMethods, Identifiable, PgConnection, QueryDsl, QueryResul
 use serde::Serialize;
 use serde_json::Value;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
 #[derive(Clone, Copy, EnumString, EnumTable)]
 #[strum(serialize_all = "camelCase")]
@@ -30,8 +32,213 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A snapshot is a version of a database resource.
+///
+/// **Field meaning**
+///
+/// - `<operation>`: what happened to the resource.
+///
+///     The value can be either of values below:
+///
+///     - `"created"` - the resource has been created
+///     - `"modified"` - the resource has been modified
+///     - `"deleted"` - the resource has been deleted
+///     - `"merged"` - the resource has been merged to another resource
+///
+/// - `<resource-type>` and `<resource-id>`: the resource that was changed.
+///
+///     The values are correlated as per table below:
+///
+///     | `<resource-type>` | `<resource-id>`                  |
+///     | ----------------- | -------------------------------  |
+///     | `"tag"`           | first tag name at given time     |
+///     | `"tag_category"`  | tag category name at given time  |
+///     | `"post"`          | post ID                          |
+///     | `"pool"`          | pool ID                          |
+///     | `"pool_category"` | pool category name at given time |
+///
+/// - `<issuer>`: a [micro user resource](#micro-user) representing the user who
+///     has made the change.
+///
+/// - `<data>`: the snapshot data, of which content depends on the `<operation>`.
+///    More explained later.
+///
+/// - `<time>`: when the snapshot was created (i.e. when the resource was changed),
+///   formatted as per RFC 3339.
+///
+/// **`<data>` field for creation snapshots**
+///
+/// The value can be either of structures below, depending on
+/// `<resource-type>`:
+///
+/// - Tag category snapshot data (`<resource-type> = "tag_category"`)
+///
+///     *Example*
+///
+///     ```json5
+///     {
+///         "name":  "character",
+///         "color": "#FF0000",
+///         "default": false
+///     }
+///     ```
+///
+/// - Tag snapshot data (`<resource-type> = "tag"`)
+///
+///     *Example*
+///
+///     ```json5
+///     {
+///         "names":        ["tag1", "tag2", "tag3"],
+///         "category":     "plain",
+///         "implications": ["imp1", "imp2", "imp3"],
+///         "suggestions":  ["sug1", "sug2", "sug3"]
+///     }
+///     ```
+///
+/// - Post snapshot data (`<resource-type> = "post"`)
+///
+///     *Example*
+///
+///     ```json5
+///     {
+///         "source": "http://example.com/",
+///         "safety": "safe",
+///         "checksum": "deadbeef",
+///         "tags": ["tag1", "tag2"],
+///         "relations": [1, 2],
+///         "notes": [<note1>, <note2>, <note3>],
+///         "flags": ["loop"],
+///         "featured": false
+///     }
+///     ```
+///     
+///     `<note>`s are serialized the same way as [note resources](#note).
+///
+/// - Pool category snapshot data (`<resource-type> = "pool_category"`)
+///
+///     *Example*
+///
+///     ```json5
+///     {
+///         "name":  "collection",
+///         "color": "#00FF00",
+///         "default": false
+///     }
+///     ```
+///
+/// - Pool snapshot data (`<resource-type> = "pool"`)
+///
+///     *Example*
+///
+///     ```json5
+///     {
+///         "names":    ["primes", "primed", "primey"],
+///         "category": "mathematical",
+///         "posts":    [2, 3, 5, 7, 11, 13, 17]
+///     }
+///     ```
+///
+///
+/// **`<data>` field for modification snapshots**
+///
+/// The value is a property-wise recursive diff between previous version of the
+/// resource and its current version. Its structure is a `<dictionary-diff>` of
+/// dictionaries as created by creation snapshots, which is described below.
+///
+/// `<primitive>`: any primitive (number or a string)
+///
+/// `<anything>`: any dictionary, list or primitive
+///
+/// `<dictionary-diff>`:
+///
+/// ```json5
+/// {
+///     "type": "object change",
+///     "value":
+///     {
+///         "property-of-any-type-1":
+///         {
+///             "type": "deleted property",
+///             "value": <anything>
+///         },
+///         "property-of-any-type-2":
+///         {
+///             "type": "added property",
+///             "value": <anything>
+///         },
+///         "primitive-property":
+///         {
+///             "type": "primitive change",
+///             "old-value": "<primitive>",
+///             "new-value": "<primitive>"
+///         },
+///         "list-property": <list-diff>,
+///         "dictionary-property": <dictionary-diff>
+///     }
+/// }
+/// ```
+///
+/// `<list-diff>`:
+///
+/// ```json5
+/// {
+///     "type": "list change",
+///     "removed": [<anything>, <anything>],
+///     "added": [<anything>, <anything>]
+/// }
+/// ```
+///
+/// Example - a diff for a post that has changed source and has one note added.
+/// Note the similarities with the structure of post creation snapshots.
+///
+/// ```json5
+/// {
+///     "type": "object change",
+///     "value":
+///     {
+///         "source":
+///         {
+///             "type": "primitive change",
+///             "old-value": None,
+///             "new-value": "new source"
+///         },
+///         "notes":
+///         {
+///             "type": "list change",
+///             "removed": [],
+///             "added":
+///             [
+///                 {"polygon": [[0, 0], [0, 1], [1, 1]], "text": "new note"}
+///             ]
+///         }
+///     }
+/// }
+/// ```
+///
+/// Since the snapshot dictionaries structure is pretty immutable, you probably
+/// won't see `added property` or `deleted property` around. This observation holds
+/// true even if the way the snapshots are generated changes - szurubooru stores
+/// just the diffs rather than original snapshots, so it wouldn't be able to
+/// generate a diff against an old version.
+///
+/// **`<data>` field for deletion snapshots**
+///
+/// Same as creation snapshot. In emergencies, it can be used to reconstruct
+/// deleted entities. Please note that this does not constitute as means against
+/// vandalism (it's still possible to cause chaos by mass editing - this should be
+/// dealt with by configuring role privileges in the config) or replace database
+/// backups.
+///
+/// **`<data>` field for merge snapshots**
+///
+/// A tuple containing 2 elements:
+///
+/// - resource type equivalent to `<resource-type>` of the target entity.
+/// - resource ID equivalent to `<resource-id>` of the target entity.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct SnapshotInfo {
     user: Option<Option<MicroUser>>,
     operation: Option<ResourceOperation>,

--- a/server/src/resource/tag.rs
+++ b/server/src/resource/tag.rs
@@ -12,12 +12,18 @@ use serde_with::skip_serializing_none;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+/// A tag resource stripped down to `names`, `category` and `usages` fields.
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MicroTag {
+    /// A list of tag names (aliases). Tagging a post with any name will automatically assign the first name from this list.
+    #[schema(value_type = Vec<SmallString>)]
     pub names: Rc<[SmallString]>,
+    /// The name of the category the given tag belongs to.
     pub category: SmallString,
+    /// The number of posts the tag was used in.
     pub usages: i64,
 }
 

--- a/server/src/resource/tag.rs
+++ b/server/src/resource/tag.rs
@@ -9,6 +9,7 @@ use diesel::{
 };
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use strum::{EnumString, EnumTable};
@@ -47,18 +48,29 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A single tag. Tags are used to let users search for posts.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TagInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The tag description (instructions how to use, history etc.). The client should render is as Markdown.
     description: Option<LargeString>,
+    /// Time the tag was created.
     creation_time: Option<DateTime>,
+    /// Time the tag was last edited.
     last_edit_time: Option<DateTime>,
+    /// The name of the category the given tag belongs to.
     category: Option<SmallString>,
+    /// A list of tag names (aliases). Tagging a post with any name will automatically assign the first name from this list.
     names: Option<Vec<SmallString>>,
+    /// A list of implied tags. Implied tags are automatically appended by the web client on usage.
     implications: Option<Vec<MicroTag>>,
+    /// A list of suggested tags. Suggested tags are shown to the user by the web client on usage.
     suggestions: Option<Vec<MicroTag>>,
+    /// The number of posts the tag was used in.
     usages: Option<i64>,
 }
 

--- a/server/src/resource/tag_category.rs
+++ b/server/src/resource/tag_category.rs
@@ -9,7 +9,9 @@ use crate::time::DateTime;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, QueryResult, RunQueryDsl, SelectableHelper};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
 #[derive(Clone, Copy, EnumString, EnumTable)]
 #[strum(serialize_all = "camelCase")]
@@ -28,14 +30,24 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A single tag category. The primary purpose of tag categories is to distinguish
+/// certain tag types (such as characters, media type etc.), which improves user
+/// experience.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct TagCategoryInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The category name.
     name: Option<SmallString>,
+    /// The category color.
     color: Option<SmallString>,
+    /// How many tags is the given category used with.
     usages: Option<i64>,
+    /// The order in which tags with this category are displayed, ascending.
     order: Option<i32>,
+    /// Whether the tag category is the default one.
     default: Option<bool>,
 }
 

--- a/server/src/resource/user.rs
+++ b/server/src/resource/user.rs
@@ -15,6 +15,7 @@ use serde_with::skip_serializing_none;
 use strum::{EnumString, EnumTable};
 use utoipa::ToSchema;
 
+/// A user resource stripped down to `name` and `avatarUrl` fields.
 #[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MicroUser {

--- a/server/src/resource/user.rs
+++ b/server/src/resource/user.rs
@@ -12,6 +12,7 @@ use diesel::dsl::count_star;
 use diesel::{BelongingToDsl, ExpressionMethods, Identifiable, PgConnection, QueryDsl, QueryResult, RunQueryDsl};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
 use utoipa::ToSchema;
 
@@ -67,22 +68,41 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A single user.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UserInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The user name.
     name: Option<SmallString>,
+    /// The user email. It is available only if the request is authenticated by the same user,
+    /// or the authenticated user can change the email. If it's unavailable, the server returns `false`.
+    /// If the user hasn't specified an email, the server returns `null`.
     email: Option<PrivateData<Option<SmallString>>>,
+    /// The user rank, which effectively affects their privileges.
     rank: Option<UserRank>,
+    /// The last login time.
     last_login_time: Option<DateTime>,
+    /// The user registration time.
     creation_time: Option<DateTime>,
+    /// How to render the user avatar.
     avatar_style: Option<AvatarStyle>,
+    /// The URL to the avatar.
     avatar_url: Option<String>,
+    /// Number of comments.
     comment_count: Option<i64>,
+    /// Number of uploaded posts.
     uploaded_post_count: Option<i64>,
+    /// Nubmer of liked posts. It is available only if the request is authenticated by the same user.
+    /// If it's unavailable, the server returns `false`.
     liked_post_count: Option<PrivateData<i64>>,
+    /// Number of disliked posts. It is available only if the request is authenticated by the same user.
+    /// If it's unavailable, the server returns `false`.
     disliked_post_count: Option<PrivateData<i64>>,
+    /// Number of favorited posts.
     favorite_post_count: Option<i64>,
 }
 
@@ -175,7 +195,7 @@ impl UserInfo {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, ToSchema)]
 #[serde(untagged)]
 enum PrivateData<T> {
     Expose(T),

--- a/server/src/resource/user.rs
+++ b/server/src/resource/user.rs
@@ -13,11 +13,16 @@ use diesel::{BelongingToDsl, ExpressionMethods, Identifiable, PgConnection, Quer
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MicroUser {
+    /// The user name.
+    #[schema(examples("username"))]
     name: SmallString,
+    /// The URL to the avatar.
+    #[schema(examples("https://gravatar.com/avatar/60602eb3c4f?d=retro&s=300"))]
     avatar_url: String,
 }
 

--- a/server/src/resource/user_token.rs
+++ b/server/src/resource/user_token.rs
@@ -5,7 +5,9 @@ use crate::string::LargeString;
 use crate::time::DateTime;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
+use server_macros::non_nullable_options;
 use strum::{EnumString, EnumTable};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 #[derive(Clone, Copy, EnumString, EnumTable)]
@@ -28,18 +30,30 @@ impl BoolFill for FieldTable<bool> {
     }
 }
 
+/// A single user token.
+#[non_nullable_options]
 #[skip_serializing_none]
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct UserTokenInfo {
+    /// Resource version. See [versioning](#Versioning).
     version: Option<DateTime>,
+    /// The user that owns the token.
     user: Option<MicroUser>,
+    /// The token that can be used to authenticate the user.
     token: Option<Uuid>,
+    /// A note that describes the token.
     note: Option<LargeString>,
+    /// Whether the token is still valid for authentication.
     enabled: Option<bool>,
+    /// Time when the token expires.
+    #[schema(nullable)]
     expiration_time: Option<Option<DateTime>>,
+    /// Time the user token was created.
     creation_time: Option<DateTime>,
+    /// Time the user token was last edited.
     last_edit_time: Option<DateTime>,
+    /// The last time this token was used during a login involving `?bump-login`.
     last_usage_time: Option<DateTime>,
 }
 

--- a/server/src/string.rs
+++ b/server/src/string.rs
@@ -11,12 +11,16 @@ use std::fmt::Display;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 /// A wrapper over [`CompactString`] that can be serialized to or deserialized from the database.
 /// Implements Small String Optimization (SSO), so it doesn't allocate if the length is 24 bytes or less.
 /// Ideal for strings that are typically short, such as tag names.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, AsExpression, FromSqlRow)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema,
+)]
 #[diesel(sql_type = Text, sql_type = Citext)]
+#[schema(value_type = String)]
 pub struct SmallString(CompactString);
 
 impl SmallString {
@@ -91,8 +95,9 @@ where
 /// A wrapper over [`Arc<str>`] that can be serialized to or deserialized from the database.
 /// It's immutable, but can be cheaply cloned and sent across threads.
 /// Meant for potentially large string, like post descriptions.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema)]
 #[diesel(sql_type = Text)]
+#[schema(value_type = String)]
 pub struct LargeString(Arc<str>);
 
 impl LargeString {

--- a/server/src/string.rs
+++ b/server/src/string.rs
@@ -20,7 +20,7 @@ use utoipa::ToSchema;
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema,
 )]
 #[diesel(sql_type = Text, sql_type = Citext)]
-#[schema(value_type = String)]
+#[schema(value_type = String, description = "")]
 pub struct SmallString(CompactString);
 
 impl SmallString {
@@ -97,7 +97,7 @@ where
 /// Meant for potentially large string, like post descriptions.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema)]
 #[diesel(sql_type = Text)]
-#[schema(value_type = String)]
+#[schema(value_type = String, description = "")]
 pub struct LargeString(Arc<str>);
 
 impl LargeString {

--- a/server/src/test.rs
+++ b/server/src/test.rs
@@ -146,7 +146,8 @@ pub async fn verify_response_with_credentials(
         app_state.config = Arc::new(config);
     }
 
-    let app = NormalizePathLayer::trim_trailing_slash().layer(api::routes(app_state));
+    let (router, _) = api::routes(app_state).split_for_parts();
+    let app = NormalizePathLayer::trim_trailing_slash().layer(router);
     let (method, path) = request
         .split_once(' ')
         .expect("Request string must have method and path separated by a space");

--- a/server/src/time.rs
+++ b/server/src/time.rs
@@ -41,11 +41,11 @@ impl Drop for Timer<'_> {
 }
 
 /// A wrapper for [`OffsetDateTime`] that serializes/deserializes according to RFC 3339.
-#[allow(clippy::unsafe_derive_deserialize)]
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema,
 )]
 #[diesel(sql_type = Timestamptz)]
+#[schema(description = "A RFC 3339 formatted datetime string")]
 pub struct DateTime(#[serde(with = "rfc3339")] OffsetDateTime);
 
 impl DateTime {

--- a/server/src/time.rs
+++ b/server/src/time.rs
@@ -41,6 +41,7 @@ impl Drop for Timer<'_> {
 }
 
 /// A wrapper for [`OffsetDateTime`] that serializes/deserializes according to RFC 3339.
+#[allow(clippy::unsafe_derive_deserialize)]
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema,
 )]

--- a/server/src/time.rs
+++ b/server/src/time.rs
@@ -9,6 +9,7 @@ use time::error::ComponentRange;
 use time::serde::rfc3339;
 use time::{Date, Month, OffsetDateTime, PrimitiveDateTime};
 use tracing::info;
+use utoipa::ToSchema;
 
 /// Used for timing things. Prints how long the object lived when dropped.
 pub struct Timer<'a> {
@@ -41,7 +42,9 @@ impl Drop for Timer<'_> {
 
 /// A wrapper for [`OffsetDateTime`] that serializes/deserializes according to RFC 3339.
 #[allow(clippy::unsafe_derive_deserialize)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow, ToSchema,
+)]
 #[diesel(sql_type = Timestamptz)]
 pub struct DateTime(#[serde(with = "rfc3339")] OffsetDateTime);
 


### PR DESCRIPTION
This PR adds annotations to the existing server code to generate an OpenAPI specification using [utoipa](https://docs.rs/utoipa/latest/utoipa/).

The API docs can be served via Swagger UI by going to `<server_url>/swagger-ui`. If you would like to try this out for yourself, this branch will be temporarily built and put on the `dev` images.