### PR TITLE
feat: Add featured post functionality to API and home controller

### DIFF
--- a/client/js/api.js
+++ b/client/js/api.js
@@ -12,6 +12,9 @@ let remoteConfigPromise = null;
 let postCount = 0;
 let diskUsage = 0;
 let serverTime = "";
+let featuredPost = null;
+let featuringTime = null;
+let featuringUser = null;
 
 class Api extends events.EventTarget {
     constructor() {
@@ -80,6 +83,9 @@ class Api extends events.EventTarget {
                 postCount = response.postCount;
                 diskUsage = response.diskUsage;
                 serverTime = response.serverTime;
+                featuredPost = response.featuredPost;
+                featuringTime = response.featuringTime;
+                featuringUser = response.featuringUser;
             });
             return remoteConfigPromise;
         } else {
@@ -97,6 +103,18 @@ class Api extends events.EventTarget {
 
     getServerTime() {
         return serverTime;
+    }
+
+    getFeaturedPost() {
+        return featuredPost;
+    }
+
+    getFeaturingTime() {
+        return featuringTime;
+    }
+
+    getFeaturingUser() {
+        return featuringUser;
     }
 
     getName() {

--- a/client/js/controllers/home_controller.js
+++ b/client/js/controllers/home_controller.js
@@ -2,6 +2,7 @@
 
 const api = require("../api.js");
 const config = require("../config.js");
+const Post = require("../models/post.js");
 const topNavigation = require("../models/top_navigation.js");
 const HomeView = require("../views/home_view.js");
 
@@ -23,6 +24,12 @@ class HomeController {
             this._homeView.setStats({
                 postCount: api.getPostCount(),
                 diskUsage: api.getDiskUsage(),
+            });
+            this._homeView.setFeaturedPost({
+                featuredPost: api.getFeaturedPost()
+                    ? Post.fromResponse(api.getFeaturedPost())
+                    : null,
+                featuringUser: api.getFeaturingUser(),
             });
         });
     }


### PR DESCRIPTION
The featured post was never actually rendering on the home screen even though all the pieces were in place.

## What changed

- **`client/js/api.js`** – Store `featuredPost`, `featuringTime`, and `featuringUser` from the `/api/info` response (these were just being thrown away before)
- **`client/js/controllers/home_controller.js`** – Actually call `setFeaturedPost()` on the home view after fetching config, wrapping the response with `Post.fromResponse()` so it plays nice with `PostContentControl`

## Why this was broken

The server was already sending featured post data back via `/api/info`, and the client had everything ready to go. `HomeView.setFeaturedPost()` and `home_featured_post.tpl` were fully implemented. The controller just never wired them together. Looks like this got lost somewhere during the Rust rewrite :)

Was killing me not having a featured post after I switched over recently from Szuru.