### PR TITLE
feat: Allow Searching Posts Using Pool Name

### DIFF
--- a/client/html/help_search_posts.tpl
+++ b/client/html/help_search_posts.tpl
@@ -36,7 +36,7 @@
         </tr>
         <tr>
             <td><code>pool</code></td>
-            <td>belonging to the pool with the given ID</td>
+            <td>belonging to the pool with the given name (accepts wildcards) or ID</td>
         </tr>
         <tr>
             <td><code>pool-category</code></td>

--- a/client/html/pool_delete.tpl
+++ b/client/html/pool_delete.tpl
@@ -1,6 +1,6 @@
 <div class='pool-delete'>
     <form>
-        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.names[0]}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
+        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.searchableName}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
 
         <ul class='input'>
             <li>

--- a/client/html/pool_delete.tpl
+++ b/client/html/pool_delete.tpl
@@ -1,6 +1,6 @@
 <div class='pool-delete'>
     <form>
-        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.id}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
+        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.names[0]}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
 
         <ul class='input'>
             <li>

--- a/client/html/pool_summary.tpl
+++ b/client/html/pool_summary.tpl
@@ -18,6 +18,6 @@
     <section class='description'>
         <hr/>
         <%= ctx.makeMarkdown(ctx.pool.description || 'This pool has no description yet.') %>
-        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.id}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
+        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.names[0]}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
     </section>
 </div>

--- a/client/html/pool_summary.tpl
+++ b/client/html/pool_summary.tpl
@@ -18,6 +18,6 @@
     <section class='description'>
         <hr/>
         <%= ctx.makeMarkdown(ctx.pool.description || 'This pool has no description yet.') %>
-        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.names[0]}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
+        <p>This pool has <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + ctx.pool.searchableName}) %>'><%- ctx.pool.postCount %> post(s)</a>.</p>
     </section>
 </div>

--- a/client/html/pools_page.tpl
+++ b/client/html/pools_page.tpl
@@ -35,7 +35,7 @@
                             </ul>
                         </td>
                         <td class='post-count'>
-                            <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + pool.names[0]}) %>'><%- pool.postCount %></a>
+                            <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + pool.searchableName}) %>'><%- pool.postCount %></a>
                         </td>
                         <td class='creation-time'>
                             <%= ctx.makeRelativeTime(pool.creationTime) %>

--- a/client/html/pools_page.tpl
+++ b/client/html/pools_page.tpl
@@ -35,7 +35,7 @@
                             </ul>
                         </td>
                         <td class='post-count'>
-                            <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + pool.id}) %>'><%- pool.postCount %></a>
+                            <a href='<%- ctx.formatClientLink('posts', {query: 'pool:' + pool.names[0]}) %>'><%- pool.postCount %></a>
                         </td>
                         <td class='creation-time'>
                             <%= ctx.makeRelativeTime(pool.creationTime) %>

--- a/client/js/controls/pool_input_control.js
+++ b/client/js/controls/pool_input_control.js
@@ -133,7 +133,7 @@ class PoolInputControl extends events.EventTarget {
 
         const poolIconNode = document.createElement("i");
         poolIconNode.classList.add("fa");
-        poolIconNode.classList.add("fa-bars");
+        poolIconNode.classList.add("fa-list-ul");
         poolLinkNode.appendChild(poolIconNode);
 
         const searchLinkNode = document.createElement("a");

--- a/client/js/controls/pool_input_control.js
+++ b/client/js/controls/pool_input_control.js
@@ -128,12 +128,12 @@ class PoolInputControl extends events.EventTarget {
         }
         poolLinkNode.setAttribute(
             "href",
-            uri.formatClientLink("pool", pool.names[0])
+            uri.formatClientLink("pool", pool.id)
         );
 
         const poolIconNode = document.createElement("i");
         poolIconNode.classList.add("fa");
-        poolIconNode.classList.add("fa-pool");
+        poolIconNode.classList.add("fa-bars");
         poolLinkNode.appendChild(poolIconNode);
 
         const searchLinkNode = document.createElement("a");
@@ -142,7 +142,7 @@ class PoolInputControl extends events.EventTarget {
         }
         searchLinkNode.setAttribute(
             "href",
-            uri.formatClientLink("posts", { query: "pool:" + pool.id })
+            uri.formatClientLink("posts", { query: "pool:" + pool.names[0]})
         );
         searchLinkNode.textContent = pool.names[0] + " ";
 

--- a/client/js/controls/pool_input_control.js
+++ b/client/js/controls/pool_input_control.js
@@ -142,7 +142,7 @@ class PoolInputControl extends events.EventTarget {
         }
         searchLinkNode.setAttribute(
             "href",
-            uri.formatClientLink("posts", { query: "pool:" + pool.names[0]})
+            uri.formatClientLink("posts", { query: "pool:" + pool.searchableName})
         );
         searchLinkNode.textContent = pool.names[0] + " ";
 

--- a/client/js/models/pool.js
+++ b/client/js/models/pool.js
@@ -27,6 +27,14 @@ class Pool extends events.EventTarget {
         return this._names;
     }
 
+    get searchableName() {
+        if (this._names.length > 0 && !/^\d+$/.test(this._names[0])) {
+            return this._names[0];
+        } else {
+            return this._id;
+        }
+    }
+
     get category() {
         return this._category;
     }

--- a/docs/API.md
+++ b/docs/API.md
@@ -713,7 +713,7 @@ data.
     | `submit`             | alias of upload                                                                         |
     | `comment`            | commented by given user (accepts wildcards)                                             |
     | `fav`                | favorited by given user (accepts wildcards)                                             |
-    | `pool`               | belonging to the pool with the given ID                                                 |
+    | `pool`               | belonging to the pool with the given name (accepts wildcards) or ID                     |
     | `pool-category`      | belonging to pools in the given pool category (accepts wildcards)                       |
     | `tag-count`          | having given number of tags                                                             |
     | `comment-count`      | having given number of comments                                                         |

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -112,7 +112,7 @@ where
 /// | `uploader`, `upload`, `submit`                               | uploaded by given user (accepts wildcards)                              |
 /// | `comment`                                                    | commented by given user (accepts wildcards)                             |
 /// | `fav`                                                        | favorited by given user (accepts wildcards)                             |
-/// | `pool`                                                       | belonging to the pool with the given ID                                 |
+/// | `pool`                                                       | belonging to the pool with the given name (accepts wildcards) or ID     |
 /// | `pool-category`                                              | belonging to pools in the given pool category (accepts wildcards)       |
 /// | `tag-count`                                                  | having given number of tags                                             |
 /// | `comment-count`                                              | having given number of comments                                         |

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -1368,6 +1368,8 @@ mod test {
             let path = format!("post/list_{token}_sorted");
             verify_response(&query, &path).await?;
         }
+        verify_response(&format!("{QUERY}=-pool:Fantasy {PARAMS}"), "post/list_pool_name_filtered").await?;
+        verify_response(&format!("{QUERY}=pool:*a*t* {PARAMS}"), "post/list_pool_name_wildcards_filtered").await?;
         verify_response(&format!("{QUERY}=special:liked {PARAMS}"), "post/list_liked_filtered").await?;
         verify_response(&format!("{QUERY}=special:disliked {PARAMS}"), "post/list_disliked_filtered").await?;
         verify_response(&format!("{QUERY}=special:tumbleweed {PARAMS}"), "post/list_tumbleweed_filtered").await

--- a/server/src/search/post.rs
+++ b/server/src/search/post.rs
@@ -4,8 +4,8 @@ use crate::config::Config;
 use crate::content::hash::Checksum;
 use crate::model::enums::{PostFlag, PostFlags, PostSafety, PostType};
 use crate::schema::{
-    comment, database_statistics, pool, pool_category, pool_post, post, post_favorite, post_feature, post_note,
-    post_score, post_statistics, post_tag, tag, tag_category, tag_name, user,
+    comment, database_statistics, pool, pool_category, pool_name, pool_post, post, post_favorite, post_feature,
+    post_note, post_score, post_statistics, post_tag, tag, tag_category, tag_name, user,
 };
 use crate::search::{
     self, Builder, CacheState, Condition, Order, ParsedSort, SearchCriteria, StrCondition, UnparsedFilter, parse,
@@ -361,10 +361,21 @@ fn apply_pool_filter(
     filter: UnparsedFilter<Token>,
     state: &mut CacheState,
 ) -> ApiResult<BoxedQuery> {
-    let pool_posts = pool_post::table.select(pool_post::post_id).into_boxed();
-    let pool_posts = apply_distinct_if_multivalued!(pool_posts, filter);
-    let filtered_posts = apply_filter!(pool_posts, pool_post::pool_id, filter.unnegated(), i64)?;
-    update_filter_cache!(conn, filtered_posts, pool_post::post_id, filter, state)?;
+    if filter.condition.parse::<i64>().is_ok() {
+        let pool_posts = pool_post::table.select(pool_post::post_id).into_boxed();
+        let pool_posts = apply_distinct_if_multivalued!(pool_posts, filter);
+        let filtered_posts = apply_filter!(pool_posts, pool_post::pool_id, filter.unnegated(), i64)?;
+        update_filter_cache!(conn, filtered_posts, pool_post::post_id, filter, state)?;
+    } else {
+        let pool_posts = pool::table
+            .inner_join(pool_post::table)
+            .inner_join(pool_name::table.on(pool_name::pool_id.eq(pool::id)))
+            .select(pool_post::post_id)
+            .distinct()
+            .into_boxed();
+        let filtered_posts = apply_str_filter!(pool_posts, pool_name::name, filter.unnegated());
+        update_filter_cache!(conn, filtered_posts, pool_post::post_id, filter, state)?;
+    }
     Ok(query)
 }
 

--- a/server/src/search/post.rs
+++ b/server/src/search/post.rs
@@ -361,18 +361,17 @@ fn apply_pool_filter(
     filter: UnparsedFilter<Token>,
     state: &mut CacheState,
 ) -> ApiResult<BoxedQuery> {
-    if filter.condition.parse::<i64>().is_ok() {
+    if parse::condition::<i64>(filter.condition).is_ok() {
         let pool_posts = pool_post::table.select(pool_post::post_id).into_boxed();
         let pool_posts = apply_distinct_if_multivalued!(pool_posts, filter);
         let filtered_posts = apply_filter!(pool_posts, pool_post::pool_id, filter.unnegated(), i64)?;
         update_filter_cache!(conn, filtered_posts, pool_post::post_id, filter, state)?;
     } else {
-        let pool_posts = pool::table
-            .inner_join(pool_post::table)
-            .inner_join(pool_name::table.on(pool_name::pool_id.eq(pool::id)))
+        let pool_posts = pool_post::table
+            .inner_join(pool_name::table.on(pool_name::pool_id.eq(pool_post::pool_id)))
             .select(pool_post::post_id)
-            .distinct()
             .into_boxed();
+        let pool_posts = apply_distinct_if_multivalued!(pool_posts, filter);
         let filtered_posts = apply_str_filter!(pool_posts, pool_name::name, filter.unnegated());
         update_filter_cache!(conn, filtered_posts, pool_post::post_id, filter, state)?;
     }

--- a/server/test/request/post/list_pool_name_filtered/response.json
+++ b/server/test/request/post/list_pool_name_filtered/response.json
@@ -1,0 +1,10 @@
+{
+    "query": "-pool:Fantasy -sort:id",
+    "offset": 0,
+    "limit": 40,
+    "total": 2,
+    "results": [
+        { "id": 3 },
+        { "id": 4 }
+    ]
+}

--- a/server/test/request/post/list_pool_name_wildcards_filtered/response.json
+++ b/server/test/request/post/list_pool_name_wildcards_filtered/response.json
@@ -1,0 +1,12 @@
+{
+    "query": "pool:*a*t* -sort:id",
+    "offset": 0,
+    "limit": 40,
+    "total": 4,
+    "results": [
+        { "id": 1 },
+        { "id": 2 },
+        { "id": 4 },
+        { "id": 5 }
+    ]
+}


### PR DESCRIPTION
This makes it possible to search posts by using the pool name as well as the pool ID. When the user searches using `pool:name`, it will notice that the value is not an int64 and will then search using the string name instead. This retains the existing searching by ID funnctionality. Wildcards are also supported by name search.

There is a limitation where pools which are valid int64s do not allowing searching by pool name, as this gets interpreted as searching by pool ID. However this does not affect any endpoints for managing pools, and only post search is affected, as this is purely to make searching pools easier for the end user. Links to the search page have been changed to use the pool name rather than ID, except for when that pool name is a valid integer, where it then reverts back to ID.

There was also an existing bug from szurubooru where on the post edit page, there is a link to the pool edit page but with the name rather than ID which with oxi and szuru would give an error page. This went unnoticed for years, likely due to being invisible. The icon was `fa-pool` which isnt a valid font awesome icon. Maybe that section of pool_input_control was originally just a blindly copied and find/replaced from tag_input_control? Anyway, I have changed it to `fa-bars` so that the button is visible, but am not sure if this is the most representative option.