### PR TITLE
server/fix: editing tag/pool categories multiple times will fail

### DIFF
--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -211,10 +211,10 @@ async fn update(
             }
 
             new_category.last_edit_time = DateTime::now();
-            let _: PoolCategory =
+            let saved_category: PoolCategory =
                 error::map_unique_violation(new_category.save_changes(conn), ResourceProperty::PoolCategoryName)?;
             snapshot::pool_category::modification_snapshot(conn, ctx.client, &old_category, &new_category)?;
-            Ok::<_, ApiError>(new_category)
+            Ok::<_, ApiError>(saved_category)
         })
         .await?;
     connection_pool

--- a/server/src/api/pool_category.rs
+++ b/server/src/api/pool_category.rs
@@ -269,11 +269,6 @@ async fn set_default(
                 .set(pool::category_id.eq(category.id))
                 .execute(conn)?;
 
-            // Update last_edit_time
-            let current_time = DateTime::now();
-            category.last_edit_time = current_time;
-            old_default_category.last_edit_time = current_time;
-
             // Make category default
             std::mem::swap(&mut category.id, &mut old_default_category.id);
 

--- a/server/src/api/tag_category.rs
+++ b/server/src/api/tag_category.rs
@@ -274,11 +274,6 @@ async fn set_default(
                 .set(tag::category_id.eq(category.id))
                 .execute(conn)?;
 
-            // Update last_edit_time
-            let current_time = DateTime::now();
-            category.last_edit_time = current_time;
-            old_default_category.last_edit_time = current_time;
-
             // Make category default
             std::mem::swap(&mut category.id, &mut old_default_category.id);
 

--- a/server/src/api/tag_category.rs
+++ b/server/src/api/tag_category.rs
@@ -215,10 +215,10 @@ async fn update(
             }
 
             new_category.last_edit_time = DateTime::now();
-            let _: TagCategory =
+            let saved_category: TagCategory =
                 error::map_unique_violation(new_category.save_changes(conn), ResourceProperty::TagCategoryName)?;
             snapshot::tag_category::modification_snapshot(conn, ctx.client, &old_category, &new_category)?;
-            Ok::<_, ApiError>(new_category)
+            Ok::<_, ApiError>(saved_category)
         })
         .await?;
     connection_pool


### PR DESCRIPTION
If you edit tag categories or pool categories multiple times without reloading the page, it will fail. This is due to precision of the timestamp differing between it being generated, and when its stored in the database, as it is truncated by the database, for example `2026-05-15T10:50:55.254454977Z` vs `2026-05-15T10:50:55.254454Z`

## steps to reproduce the issue

- go to the tag category edit page (or pool category edit page)
- change one of the categories, and then save
- do not refresh the page
- change another one of the categories again (or the same one again), and then save again
- an error is displayed, and the changes were not saved

## the fix

Tag and pool categories now use the value that was just written to the database when giving the last edit time to the user, so when the database truncates it, the user receives that same truncated value.