### PR TITLE
server/feat: Added more accurate animation detection (AVIF, GIF, WEBP)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -40,7 +40,6 @@ RUN ./configure \
     --disable-podpages \
     --disable-txtpages \
     --disable-debug \
-    --disable-ffprobe \
     --disable-shared \
     --disable-pic \
     \
@@ -60,12 +59,16 @@ RUN ./configure \
     --extra-ldexeflags="-static -no-pie" \
     --pkg-config-flags="--static" \
   && make -j$(nproc) \
-  && strip ffmpeg
+  && strip ffmpeg \
+  && strip ffprobe
 
 # Verify ffmpeg has no dynamic dependencies
 RUN readelf -d ffmpeg | grep -q "NEEDED" \
   && (echo "ffmpeg has dynamic dependencies!" && readelf -d ffmpeg | grep NEEDED && exit 1) \
   || echo "ffmpeg is fully static"
+RUN readelf -d ffprobe | grep -q "NEEDED" \
+  && (echo "ffprobe has dynamic dependencies!" && readelf -d ffmpeg | grep NEEDED && exit 1) \
+  || echo "ffprobe is fully static"
 
 ############################## Planning Phase ##############################
 FROM lukemathwalker/cargo-chef:${CHEF_VERSION}-rust-${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
@@ -119,6 +122,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 # Copy binaries with ownership
 COPY --from=ffmpeg_builder --chown=${PUID}:${PGID} /build/ffmpeg-${FFMPEG_VERSION}/ffmpeg /opt/app/ffmpeg
+COPY --from=ffmpeg_builder --chown=${PUID}:${PGID} /build/ffmpeg-${FFMPEG_VERSION}/ffprobe /opt/app/ffprobe
 COPY --from=builder --chown=${PUID}:${PGID} /opt/app/target/release/oxibooru_server /opt/app/server
 
 # Run it!

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -40,6 +40,7 @@ RUN ./configure \
     --disable-podpages \
     --disable-txtpages \
     --disable-debug \
+    --disable-ffprobe \
     --disable-shared \
     --disable-pic \
     \
@@ -59,16 +60,12 @@ RUN ./configure \
     --extra-ldexeflags="-static -no-pie" \
     --pkg-config-flags="--static" \
   && make -j$(nproc) \
-  && strip ffmpeg \
-  && strip ffprobe
+  && strip ffmpeg
 
 # Verify ffmpeg has no dynamic dependencies
 RUN readelf -d ffmpeg | grep -q "NEEDED" \
   && (echo "ffmpeg has dynamic dependencies!" && readelf -d ffmpeg | grep NEEDED && exit 1) \
   || echo "ffmpeg is fully static"
-RUN readelf -d ffprobe | grep -q "NEEDED" \
-  && (echo "ffprobe has dynamic dependencies!" && readelf -d ffmpeg | grep NEEDED && exit 1) \
-  || echo "ffprobe is fully static"
 
 ############################## Planning Phase ##############################
 FROM lukemathwalker/cargo-chef:${CHEF_VERSION}-rust-${RUST_VERSION}-alpine${ALPINE_VERSION} AS chef
@@ -122,7 +119,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 # Copy binaries with ownership
 COPY --from=ffmpeg_builder --chown=${PUID}:${PGID} /build/ffmpeg-${FFMPEG_VERSION}/ffmpeg /opt/app/ffmpeg
-COPY --from=ffmpeg_builder --chown=${PUID}:${PGID} /build/ffmpeg-${FFMPEG_VERSION}/ffprobe /opt/app/ffprobe
 COPY --from=builder --chown=${PUID}:${PGID} /opt/app/target/release/oxibooru_server /opt/app/server
 
 # Run it!

--- a/server/src/admin/mod.rs
+++ b/server/src/admin/mod.rs
@@ -82,6 +82,8 @@ pub enum AdminTask {
     RecomputeSignatures,
     #[strum(message = "Rebuild reverse search index")]
     RecomputeIndex,
+    #[strum(message = "Recompute post types")]
+    RecomputePostTypes,
     #[strum(message = "Regenerate post thumbnails")]
     RegenerateThumbnails,
     #[strum(message = "Reset user passwords")]
@@ -197,6 +199,7 @@ fn run_task(state: &AppState, task: AdminTask, post_editor: &mut PostEditor, use
         AdminTask::RecomputeChecksums => post::recompute_checksums(state, post_editor),
         AdminTask::RecomputeSignatures => post::recompute_signatures(state, post_editor),
         AdminTask::RecomputeIndex => post::recompute_indexes(state, post_editor),
+        AdminTask::RecomputePostTypes => post::recompute_post_types(state, post_editor),
         AdminTask::RegenerateThumbnails => post::regenerate_thumbnails(state, post_editor),
         AdminTask::ResetPasswords => user::reset_password(state, user_editor),
         AdminTask::ResetFilenames => database::reset_filenames(state),

--- a/server/src/admin/post.rs
+++ b/server/src/admin/post.rs
@@ -91,6 +91,20 @@ pub fn recompute_indexes(state: &AppState, editor: &mut PostEditor) {
     });
 }
 
+/// Recomputes post types.
+/// Meant to apply changes to existing posts when post type definitions change.
+pub fn recompute_post_types(state: &AppState, editor: &mut PostEditor) {
+    input::user_input_loop(state, editor, |state: &AppState, editor: &mut PostEditor| {
+        let post_ids = user_query(state, editor)?;
+
+        let _timer = Timer::new("recompute_post_types");
+        let progress = ProgressReporter::new("Post types computed", PRINT_INTERVAL);
+        post_ids
+            .into_par_iter()
+            .try_for_each(|post_id| recompute_post_type_in_parallel(state, post_id, &progress))
+    });
+}
+
 pub fn regenerate_thumbnails(state: &AppState, editor: &mut PostEditor) {
     input::user_input_loop(state, editor, |state: &AppState, editor: &mut PostEditor| {
         let post_ids = user_query(state, editor)?;
@@ -292,6 +306,45 @@ fn recompute_signature_in_parallel(state: &AppState, post_id: i64, progress: &Pr
     match transaction_result {
         Ok(_) => progress.increment(),
         Err(err) => error!("Unable to update post signature for post {post_id} for reason: {err}"),
+    }
+    Ok(())
+}
+
+/// Recomputes post type for post with id `post_id`. Designed to operate in a parallel iterator.
+fn recompute_post_type_in_parallel(state: &AppState, post_id: i64, progress: &ProgressReporter) -> AdminResult<()> {
+    admin::is_cancelled()?;
+
+    let mut conn = state.connection_pool.get_blocking()?;
+    let mime_type = match post::table
+        .find(post_id)
+        .select(post::mime_type)
+        .first(&mut conn)
+        .optional()
+    {
+        Ok(Some(mime_type)) => mime_type,
+        Ok(None) => return Ok(()), // Post must have been deleted after starting task, skip
+        Err(err) => {
+            error!("Cannot retrieve MIME type for post {post_id} for reason: {err}");
+            return Ok(());
+        }
+    };
+
+    let post_hash = PostHash::new(&state.config, post_id);
+    let content_path = post_hash.content_path(mime_type);
+    let post_type = match decode::detect_post_type(&content_path, mime_type) {
+        Ok(type_) => type_,
+        Err(err) => {
+            error!("Cannot detect post type for post {post_id} for reason: {err}");
+            return Ok(());
+        }
+    };
+
+    match diesel::update(post::table.find(post_id))
+        .set(post::type_.eq(post_type))
+        .execute(&mut conn)
+    {
+        Ok(_) => progress.increment(),
+        Err(err) => error!("Type update failed for post {post_id} for reason: {err}"),
     }
     Ok(())
 }

--- a/server/src/api/post.rs
+++ b/server/src/api/post.rs
@@ -10,7 +10,7 @@ use crate::content::upload::{MAX_UPLOAD_SIZE, PartName, UploadToken};
 use crate::content::{Content, signature, upload};
 use crate::db::AsyncConnectionPool;
 use crate::extract::{Ctx, Json, JsonOrMultipart, Path, Query};
-use crate::model::enums::{PostFlag, PostFlags, PostSafety, PostType, ResourceProperty, ResourceType, Score};
+use crate::model::enums::{PostFlag, PostFlags, PostSafety, ResourceProperty, ResourceType, Score};
 use crate::model::post::{NewPost, NewPostFeature, NewPostSignature, Post, PostFavorite, PostScore, PostSignature};
 use crate::resource::post::{Field, Note, PostInfo};
 use crate::schema::{post, post_favorite, post_feature, post_score, post_signature, post_statistics};
@@ -620,7 +620,7 @@ async fn create_impl(ctx: Ctx, params: ResourceParams<Field>, body: PostCreateBo
                 width: content_properties.width,
                 height: content_properties.height,
                 safety: body.safety,
-                type_: PostType::from(content_properties.mime_type),
+                type_: content_properties.post_type,
                 mime_type: content_properties.mime_type,
                 checksum: content_properties.checksum,
                 checksum_md5: content_properties.md5_checksum,
@@ -1028,7 +1028,7 @@ async fn update_impl(
                 new_post.file_size = content_properties.file_size;
                 new_post.width = content_properties.width;
                 new_post.height = content_properties.height;
-                new_post.type_ = PostType::from(content_properties.mime_type);
+                new_post.type_ = content_properties.post_type;
                 new_post.mime_type = content_properties.mime_type;
                 new_post.checksum = content_properties.checksum;
                 new_post.checksum_md5 = content_properties.md5_checksum;

--- a/server/src/content/cache.rs
+++ b/server/src/content/cache.rs
@@ -22,6 +22,7 @@ pub struct CachedProperties {
     pub width: i32,
     pub height: i32,
     pub mime_type: MimeType,
+    pub post_type: PostType,
     pub file_size: i64,
     pub flags: PostFlags,
 }
@@ -87,7 +88,7 @@ fn compute_properties_no_cache(ctx: &Ctx, token: UploadToken) -> ApiResult<Cache
     let (checksum, md5_checksum) = content::map_read_result(hash::compute_checksums(&temp_path))?;
 
     let mime_type = token.mime_type();
-    let post_type = PostType::from(mime_type);
+    let post_type = decode::detect_post_type(&temp_path, mime_type)?;
     let has_sound = match post_type {
         PostType::Image | PostType::Animation => false,
         PostType::Video => decode::video_has_audio(&temp_path)?,
@@ -110,6 +111,7 @@ fn compute_properties_no_cache(ctx: &Ctx, token: UploadToken) -> ApiResult<Cache
         width: i32::try_from(image.width()).map_err(|_| LimitErrorKind::DimensionError)?,
         height: i32::try_from(image.height()).map_err(|_| LimitErrorKind::DimensionError)?,
         mime_type,
+        post_type,
         file_size,
         flags,
     })

--- a/server/src/content/decode.rs
+++ b/server/src/content/decode.rs
@@ -9,7 +9,6 @@ use image::{AnimationDecoder, DynamicImage, ImageDecoder, ImageFormat, ImageRead
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
-use std::process::Command;
 use swf::Tag;
 use tracing::error;
 
@@ -102,7 +101,7 @@ pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<Post
     }
 
     match mime_type {
-        MimeType::Avif => Ok(image_type(ffprobe_frame_count(file_path)? > 1)),
+        MimeType::Avif => Ok(image_type(is_animated(file_path)?)),
         MimeType::Gif => Ok(image_type(gif_is_animated(file_path)?)),
         MimeType::Webp => Ok(image_type(webp_is_animated(file_path)?)),
         MimeType::Bmp | MimeType::Jpeg | MimeType::Png => Ok(PostType::Image),
@@ -112,7 +111,6 @@ pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<Post
 }
 
 const FFMPEG_PATH: &str = "/opt/app/ffmpeg";
-const FFPROBE_PATH: &str = "/opt/app/ffprobe";
 
 /// Decodes a representative frame of the image or video at the given `path`.
 fn ffmpeg_frame(path: &Path, post_type: PostType) -> ApiResult<Option<DynamicImage>> {
@@ -214,6 +212,52 @@ fn flash_image(config: &Config, path: &Path) -> ApiResult<Option<DynamicImage>> 
     Ok(images.into_iter().next())
 }
 
+/// Uses `FFmpeg` to determine if a file contains multiple frames
+fn is_animated(path: &Path) -> ApiResult<bool> {
+    let path_str = path.to_string_lossy();
+    let video_stream_count = FfmpegCommand::new_with_path(FFMPEG_PATH)
+        .input(&path_str)
+        .spawn()?
+        .iter()
+        .map_err(|err| ApiError::FfmpegError(err.into_boxed_dyn_error()))?
+        .filter(|event| matches!(event, FfmpegEvent::ParsedInputStream(stream) if stream.is_video()))
+        .count();
+
+    for stream_index in 0..video_stream_count {
+        let iter = FfmpegCommand::new_with_path(FFMPEG_PATH)
+            .input(&path_str)
+            .args([
+                "-map",
+                &format!("0:v:{stream_index}"),
+                "-frames:v",
+                "2",
+                "-vf",
+                "scale=1:1:flags=neighbor",
+            ])
+            .rawvideo()
+            .spawn()?
+            .iter()
+            .map_err(|err| ApiError::FfmpegError(err.into_boxed_dyn_error()))?;
+
+        let mut frames = 0;
+        let mut errors = Vec::new();
+        for event in iter {
+            match event {
+                FfmpegEvent::OutputFrame(_) => frames += 1,
+                FfmpegEvent::Log(LogLevel::Error | LogLevel::Fatal, err) => errors.push(err),
+                _ => {}
+            }
+        }
+
+        if frames > 1 {
+            return Ok(true);
+        } else if frames == 0 && !errors.is_empty() {
+            return Err(ApiError::FfmpegError(errors.join("; ").into()));
+        }
+    }
+    Ok(false)
+}
+
 fn gif_is_animated(path: &Path) -> ApiResult<bool> {
     let file = content::map_read_result(File::open(path))?;
     let mut decoder = GifDecoder::new(BufReader::new(file))?;
@@ -229,29 +273,6 @@ fn webp_is_animated(path: &Path) -> ApiResult<bool> {
     let mut decoder = WebPDecoder::new(BufReader::new(file))?;
     decoder.set_limits(image_reader_limits())?;
     Ok(decoder.has_animation())
-}
-
-/// Count frames in an animated image
-fn ffprobe_frame_count(path: &Path) -> ApiResult<u64> {
-    let output = Command::new(FFPROBE_PATH)
-        .args([
-            "-v",
-            "error",
-            "-count_frames",
-            "-select_streams",
-            "v:0",
-            "-show_entries",
-            "stream=nb_read_frames",
-            "-of",
-            "csv=p=0",
-        ])
-        .arg(path)
-        .output()?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    stdout
-        .parse::<u64>()
-        .map_err(|_| ApiError::FfmpegError("Unable to count frames with FFprobe".into()))
 }
 
 /// Returns maximum decoded image size.

--- a/server/src/content/decode.rs
+++ b/server/src/content/decode.rs
@@ -14,7 +14,7 @@ use tracing::error;
 
 /// Returns a representative image for the given content.
 /// For images, this is simply the decoded image.
-/// For videos, FFmpeg determines the thumbnail.
+/// For videos, `FFmpeg` determines the thumbnail.
 /// For Flash media, it is the largest image that can be decoded from the Flash tags.
 pub fn representative_image(config: &Config, file_path: &Path, mime_type: MimeType) -> ApiResult<DynamicImage> {
     match mime_type {

--- a/server/src/content/decode.rs
+++ b/server/src/content/decode.rs
@@ -4,10 +4,12 @@ use crate::content::{self, flash};
 use crate::model::enums::{MimeType, PostType};
 use ffmpeg_sidecar::command::FfmpegCommand;
 use ffmpeg_sidecar::event::{FfmpegEvent, LogLevel};
-use image::{DynamicImage, ImageFormat, ImageReader, Limits, RgbImage, RgbaImage};
+use image::codecs::{gif::GifDecoder, webp::WebPDecoder};
+use image::{AnimationDecoder, DynamicImage, ImageDecoder, ImageFormat, ImageReader, Limits, RgbImage, RgbaImage};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+use std::process::Command;
 use swf::Tag;
 use tracing::error;
 
@@ -86,7 +88,28 @@ pub fn image(file_path: &Path, mime_type: MimeType) -> ApiResult<DynamicImage> {
     }
 }
 
+/// Returns the post type based on file content.
+/// For image formats that support animation, it checks the file content for multiple frames.
+/// For everything else, it just checks the mime type.
+pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<PostType> {
+    if let Some(is_animation) = match mime_type {
+        MimeType::Avif => Some(ffprobe_frame_count(file_path)? > 1),
+        MimeType::Gif => Some(gif_is_animated(file_path)?),
+        MimeType::Webp => Some(webp_is_animated(file_path)?),
+        _ => None,
+    } {
+        if is_animation {
+            Ok(PostType::Animation)
+        } else {
+            Ok(PostType::Image)
+        }
+    } else {
+        Ok(PostType::from(mime_type))
+    }
+}
+
 const FFMPEG_PATH: &str = "/opt/app/ffmpeg";
+const FFPROBE_PATH: &str = "/opt/app/ffprobe";
 
 /// Decodes a representative frame of the image or video at the given `path`.
 fn ffmpeg_frame(path: &Path, post_type: PostType) -> ApiResult<Option<DynamicImage>> {
@@ -186,6 +209,46 @@ fn flash_image(config: &Config, path: &Path) -> ApiResult<Option<DynamicImage>> 
         u32::MAX - effective_width
     });
     Ok(images.into_iter().next())
+}
+
+fn gif_is_animated(path: &Path) -> ApiResult<bool> {
+    let file = content::map_read_result(File::open(path))?;
+    let mut decoder = GifDecoder::new(BufReader::new(file))?;
+    decoder.set_limits(image_reader_limits())?;
+
+    // GIF doesn't store a frame count, so just check for a second frame.
+    let mut frames = decoder.into_frames();
+    Ok(frames.nth(1).is_some())
+}
+
+fn webp_is_animated(path: &Path) -> ApiResult<bool> {
+    let file = content::map_read_result(File::open(path))?;
+    let mut decoder = WebPDecoder::new(BufReader::new(file))?;
+    decoder.set_limits(image_reader_limits())?;
+    Ok(decoder.has_animation())
+}
+
+/// Count frames in an animated image
+fn ffprobe_frame_count(path: &Path) -> ApiResult<u64> {
+    let output = Command::new(FFPROBE_PATH)
+        .args([
+            "-v",
+            "error",
+            "-count_frames",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "csv=p=0",
+        ])
+        .arg(path)
+        .output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    stdout
+        .parse::<u64>()
+        .map_err(|_| ApiError::FfmpegError("Unable to count frames with FFprobe".into()))
 }
 
 /// Returns maximum decoded image size.

--- a/server/src/content/decode.rs
+++ b/server/src/content/decode.rs
@@ -92,19 +92,22 @@ pub fn image(file_path: &Path, mime_type: MimeType) -> ApiResult<DynamicImage> {
 /// For image formats that support animation, it checks the file content for multiple frames.
 /// For everything else, it just checks the mime type.
 pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<PostType> {
-    if let Some(is_animation) = match mime_type {
-        MimeType::Avif => Some(ffprobe_frame_count(file_path)? > 1),
-        MimeType::Gif => Some(gif_is_animated(file_path)?),
-        MimeType::Webp => Some(webp_is_animated(file_path)?),
-        _ => None,
-    } {
-        if is_animation {
-            Ok(PostType::Animation)
+    // Shorthand to return PostType::Animation or PostType::Image based on bool input
+    fn image_type(is_animated: bool) -> PostType {
+        if is_animated {
+            PostType::Animation
         } else {
-            Ok(PostType::Image)
+            PostType::Image
         }
-    } else {
-        Ok(PostType::from(mime_type))
+    }
+
+    match mime_type {
+        MimeType::Avif => Ok(image_type(ffprobe_frame_count(file_path)? > 1)),
+        MimeType::Gif => Ok(image_type(gif_is_animated(file_path)?)),
+        MimeType::Webp => Ok(image_type(webp_is_animated(file_path)?)),
+        MimeType::Bmp | MimeType::Jpeg | MimeType::Png => Ok(PostType::Image),
+        MimeType::Mp4 | MimeType::Mov | MimeType::Webm => Ok(PostType::Video),
+        MimeType::Swf => Ok(PostType::Flash),
     }
 }
 

--- a/server/src/content/decode.rs
+++ b/server/src/content/decode.rs
@@ -14,13 +14,21 @@ use tracing::error;
 
 /// Returns a representative image for the given content.
 /// For images, this is simply the decoded image.
-/// For videos, it is the first frame of the video.
+/// For videos, FFmpeg determines the thumbnail.
 /// For Flash media, it is the largest image that can be decoded from the Flash tags.
 pub fn representative_image(config: &Config, file_path: &Path, mime_type: MimeType) -> ApiResult<DynamicImage> {
-    match PostType::from(mime_type) {
-        PostType::Image | PostType::Animation => image(file_path, mime_type),
-        PostType::Video => ffmpeg_frame(file_path, PostType::Video).and_then(|frame| frame.ok_or(ApiError::EmptyVideo)),
-        PostType::Flash => flash_image(config, file_path).and_then(|frame| frame.ok_or(ApiError::EmptySwf)),
+    match mime_type {
+        MimeType::Bmp => image(file_path, ImageFormat::Bmp),
+        MimeType::Gif => image(file_path, ImageFormat::Gif),
+        MimeType::Jpeg => image(file_path, ImageFormat::Jpeg),
+        MimeType::Png => image(file_path, ImageFormat::Png),
+        MimeType::Webp => image(file_path, ImageFormat::WebP),
+        MimeType::Swf => flash_image(config, file_path).and_then(|frame| frame.ok_or(ApiError::EmptySwf)),
+        MimeType::Avif => ffmpeg_frame(file_path, PostType::Image)
+            .and_then(|frame| frame.ok_or(ApiError::FfmpegError("Unable to decode AVIF image with FFmpeg".into()))),
+        MimeType::Mov | MimeType::Mp4 | MimeType::Webm => {
+            ffmpeg_frame(file_path, PostType::Video).and_then(|frame| frame.ok_or(ApiError::EmptyVideo))
+        }
     }
 }
 
@@ -72,38 +80,16 @@ pub fn swf_has_audio(path: &Path) -> ApiResult<bool> {
     }))
 }
 
-/// Decodes a raw array of bytes into pixel data.
-pub fn image(file_path: &Path, mime_type: MimeType) -> ApiResult<DynamicImage> {
-    if let Some(format) = mime_type.to_image_format() {
-        let file = content::map_read_result(File::open(file_path))?;
-
-        let mut reader = ImageReader::new(BufReader::new(file));
-        reader.set_format(format);
-        reader.limits(image_reader_limits());
-        reader.decode().map_err(ApiError::from)
-    } else {
-        ffmpeg_frame(file_path, PostType::Image)?
-            .ok_or(ApiError::FfmpegError(format!("Unable to decode {mime_type} image with FFmpeg").into()))
-    }
-}
-
 /// Returns the post type based on file content.
 /// For image formats that support animation, it checks the file content for multiple frames.
 /// For everything else, it just checks the mime type.
 pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<PostType> {
     // Shorthand to return PostType::Animation or PostType::Image based on bool input
-    fn image_type(is_animated: bool) -> PostType {
-        if is_animated {
-            PostType::Animation
-        } else {
-            PostType::Image
-        }
-    }
-
+    let image_type = |animated: bool| -> PostType { if animated { PostType::Animation } else { PostType::Image } };
     match mime_type {
-        MimeType::Avif => Ok(image_type(is_animated(file_path)?)),
-        MimeType::Gif => Ok(image_type(gif_is_animated(file_path)?)),
-        MimeType::Webp => Ok(image_type(webp_is_animated(file_path)?)),
+        MimeType::Avif => avif_is_animated(file_path).map(image_type),
+        MimeType::Gif => gif_is_animated(file_path).map(image_type),
+        MimeType::Webp => webp_is_animated(file_path).map(image_type),
         MimeType::Bmp | MimeType::Jpeg | MimeType::Png => Ok(PostType::Image),
         MimeType::Mp4 | MimeType::Mov | MimeType::Webm => Ok(PostType::Video),
         MimeType::Swf => Ok(PostType::Flash),
@@ -111,6 +97,16 @@ pub fn detect_post_type(file_path: &Path, mime_type: MimeType) -> ApiResult<Post
 }
 
 const FFMPEG_PATH: &str = "/opt/app/ffmpeg";
+
+/// Decodes a raw array of bytes into pixel data.
+fn image(file_path: &Path, format: ImageFormat) -> ApiResult<DynamicImage> {
+    let file = content::map_read_result(File::open(file_path))?;
+
+    let mut reader = ImageReader::new(BufReader::new(file));
+    reader.set_format(format);
+    reader.limits(image_reader_limits());
+    reader.decode().map_err(ApiError::from)
+}
 
 /// Decodes a representative frame of the image or video at the given `path`.
 fn ffmpeg_frame(path: &Path, post_type: PostType) -> ApiResult<Option<DynamicImage>> {
@@ -213,7 +209,7 @@ fn flash_image(config: &Config, path: &Path) -> ApiResult<Option<DynamicImage>> 
 }
 
 /// Uses `FFmpeg` to determine if a file contains multiple frames
-fn is_animated(path: &Path) -> ApiResult<bool> {
+fn avif_is_animated(path: &Path) -> ApiResult<bool> {
     let path_str = path.to_string_lossy();
     let video_stream_count = FfmpegCommand::new_with_path(FFMPEG_PATH)
         .input(&path_str)

--- a/server/src/model/enums.rs
+++ b/server/src/model/enums.rs
@@ -4,7 +4,6 @@ use diesel::pg::{Pg, PgValue};
 use diesel::serialize::{self, IsNull, Output, ToSql};
 use diesel::sql_types::SmallInt;
 use diesel::{AsExpression, FromSqlRow};
-use image::ImageFormat;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::ops::{BitOr, BitOrAssign};
@@ -72,17 +71,6 @@ pub enum PostType {
     Animation,
     Video,
     Flash,
-}
-
-impl From<MimeType> for PostType {
-    fn from(value: MimeType) -> Self {
-        match value {
-            MimeType::Avif | MimeType::Bmp | MimeType::Jpeg | MimeType::Png | MimeType::Webp => Self::Image,
-            MimeType::Gif => Self::Animation,
-            MimeType::Mp4 | MimeType::Mov | MimeType::Webm => Self::Video,
-            MimeType::Swf => Self::Flash,
-        }
-    }
 }
 
 impl ToSql<SmallInt, Pg> for PostType {
@@ -164,21 +152,6 @@ impl MimeType {
             Self::Mov => "mov",
             Self::Webm => "webm",
             Self::Swf => "swf",
-        }
-    }
-
-    /// Returns corresponding [`ImageFormat`] if [`MimeType`] is an image format
-    /// supported for decoding by the `image` crate.
-    ///
-    /// Returns [`None`] otherwise.
-    pub fn to_image_format(self) -> Option<ImageFormat> {
-        match self {
-            MimeType::Bmp => Some(ImageFormat::Bmp),
-            MimeType::Gif => Some(ImageFormat::Gif),
-            MimeType::Jpeg => Some(ImageFormat::Jpeg),
-            MimeType::Png => Some(ImageFormat::Png),
-            MimeType::Webp => Some(ImageFormat::WebP),
-            MimeType::Avif | MimeType::Mov | MimeType::Mp4 | MimeType::Webm | MimeType::Swf => None,
         }
     }
 }


### PR DESCRIPTION
This pull adds some extra logic when applying `PostType` to new uploads, applying `PostType::Animation` to AVIF, GIF, and WEBP files that have multiple frames. It also applies `PostType::Image` to GIF files with only one frame. Other file types are unaffected, and use `PostType::from(mime_type)` like before. This is only done once per upload, and is stored as a new property `post_type` in `CachedProperties`.

There is also a new admin task `recompute_post_types` to update existing posts.

The main downside is it uses `ffprobe` for AVIF files since they're not in the `image` crate, which means it can't be skipped in the Dockerfile in this case.