### PR TITLE
fix: allow 'checksumMD5' when selecting fields

### DIFF
--- a/server/src/resource/post.rs
+++ b/server/src/resource/post.rs
@@ -97,6 +97,7 @@ pub enum Field {
     Type,
     MimeType,
     Checksum,
+    #[strum(serialize = "checksumMd5", serialize = "checksumMD5")]
     ChecksumMd5,
     Flags,
     Source,


### PR DESCRIPTION
The `#[strum(serialize_all = "camelCase")]` changed the capitalization of the field name used when selecting fields when listing posts. Breaking compatibility with the szurubooru api and being inconsistent with the field name in the response.

The current capitalization of `checksumMd5` is still allowed to prevent unnecessary breakage.