### PR TITLE
server/fix: Lowercase wildcard LIKE patterns

### DIFF
--- a/server/src/search/macros.rs
+++ b/server/src/search/macros.rs
@@ -47,17 +47,21 @@ macro_rules! apply_str_filter {
             $crate::search::StrCondition::Regular(condition) => {
                 $crate::apply_condition!($query, $expression, $filter, condition)
             }
-            $crate::search::StrCondition::WildCard(pattern) => match $filter.negated {
+            $crate::search::StrCondition::WildCard(pattern) => {
                 // Even though most text-based columns are CITEXT, we cast to lower
                 // here to get PostgreSQL to use TEXT index. We do this because CITEXT
-                // indexes do not work with patterns.
-                false => $query.filter($crate::string::lower($expression).like(pattern)),
-                true => $query.filter(
-                    $crate::string::lower($expression)
-                        .not_like(pattern)
-                        .or($expression.is_null()),
-                ),
-            },
+                // indexes do not work with patterns. The pattern has to be lowered as
+                // well, and it's done in SQL so that it matches the column exactly.
+                let pattern = $crate::string::lower_pattern(pattern);
+                match $filter.negated {
+                    false => $query.filter($crate::string::lower($expression).like(pattern)),
+                    true => $query.filter(
+                        $crate::string::lower($expression)
+                            .not_like(pattern)
+                            .or($expression.is_null()),
+                    ),
+                }
+            }
         }
     }};
 }

--- a/server/src/string.rs
+++ b/server/src/string.rs
@@ -17,6 +17,9 @@ use utoipa::ToSchema;
 #[declare_sql_function]
 extern "SQL" {
     fn lower<T: SingleValue>(text: T) -> Text;
+
+    #[sql_name = "lower"]
+    fn lower_pattern(pattern: Text) -> Text;
 }
 
 /// A wrapper over a [`String`] that's meant to contain sensitive data.


### PR DESCRIPTION
Thank you for your work on this project.

This change is a fix for a regression introduced in 5628be43 that causes wildcard string searches containing uppercase characters to match nothing.

### Steps to reproduce

1. Create a tag named `Foo_Bar`.
2. Search `tag:*Foo*` → 0 results.
3. Search `tag:*foo*` → found.

### Fix

Lowercase each literal character in `to_like_pattern`.